### PR TITLE
removes appVolumesEnabled

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for TrueCharts
 type: library
-version: 0.12.0
+version: 0.12.1
 # upstream_version: 2.4.0
 keywords:
   - truecharts

--- a/library/common/templates/custom/_appStorage.tpl
+++ b/library/common/templates/custom/_appStorage.tpl
@@ -14,7 +14,7 @@ Retrieve host path from ix volumes based on dataset name
 Define appVolumeMounts for container
 */}}
 {{- define "common.custom.configuredAppVolumeMounts" -}}
-{{- if and .Values.appVolumesEnabled .Values.appVolumeMounts }}
+{{- if .Values.appVolumeMounts }}
 {{- range $name, $avm := .Values.appVolumeMounts -}}
 {{- if $avm.enabled }}
 - name: {{ $name }}
@@ -31,7 +31,7 @@ Define appVolumeMounts for container
 Define hostPath for appVolumes
 */}}
 {{- define "common.custom.configuredAppVolumes" -}}
-{{- if and .Values.appVolumesEnabled .Values.appVolumeMounts }}
+{{- if .Values.appVolumeMounts }}
 {{- range $name, $av := .Values.appVolumeMounts -}}
 {{- if $av.enabled }}
 - name: {{ $name }}


### PR DESCRIPTION
**Description**

This removes the `appVolumesEnabled` boolean, as it's not needed and is causing issues along the line. (as we don't want SCALE-only settings inside values.yaml)
It also shouldn't be needed.