### PR TITLE
Set mounted folder permissions

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: common-test
 description: Helper chart to test different use cases of the common library
-version: 1.2.1
+version: 1.3.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - truecharts

--- a/library/common-test/ci/basic-values.yaml
+++ b/library/common-test/ci/basic-values.yaml
@@ -18,7 +18,7 @@ probes:
   startup:
     enabled: true
 
-
+fixMountPermissions: false
 appVolumeMounts:
   data:
     enabled: true
@@ -34,7 +34,7 @@ appVolumeMounts:
     mountPath: "/test"
     hostPathEnabled: true
     hostPath: "/tmp"
-    
+
 appAdditionalServicesEnabled: true
 appAdditionalServices:
   extra-tcp:

--- a/library/common-test/ci/codeserver-values.yaml
+++ b/library/common-test/ci/codeserver-values.yaml
@@ -26,7 +26,7 @@ addons:
     - name: config
       mountPath: /www/assets
     
-
+fixMountPermissions: false
 appVolumeMounts:
   data:
     enabled: true

--- a/library/common-test/values.yaml
+++ b/library/common-test/values.yaml
@@ -10,6 +10,7 @@ service:
 ingress:
   enabled: true
 
+fixMountPermissions: false
 appVolumeMounts:
   data:
     enabled: true
@@ -25,7 +26,7 @@ appVolumeMounts:
     mountPath: "/test"
     hostPathEnabled: false
     hostPath: ""
-    
+
 appAdditionalServicesEnabled: true
 appAdditionalServices:
   extra-tcp:

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: common
 description: Function library for TrueCharts
 type: library
-version: 1.1.1
+version: 1.2.0
+
 kubeVersion: ">=1.16.0-0"
 # upstream_version: 3.0.1
 keywords:

--- a/library/common/templates/_all.tpl
+++ b/library/common/templates/_all.tpl
@@ -36,4 +36,5 @@ Main entrypoint for the common library chart. It will render all underlying temp
   {{ include "common.ingress" .  | nindent 0 }}
   {{- print "---" | nindent 0 -}}
   {{ include "common.custom.appIngress" .  | nindent 0 }}
+  {{ include "common.custom.mountpermissions" .  | nindent 0 }}
 {{- end -}}

--- a/library/common/templates/custom/_mountPermissions.yaml
+++ b/library/common/templates/custom/_mountPermissions.yaml
@@ -1,0 +1,21 @@
+{{/*
+This template serves as the blueprint for the mountPermissions job that is run 
+before chart installation.
+*/}}
+{{- define "common.custom.mountpermissions" -}}
+{{- if and .Values.appVolumeMounts .Values.fixMountPermissions }}
+{{- range $name, $avm := .Values.appVolumeMounts -}}
+{{- if and $avm.enabled $avm.setPermissions}}
+{{- print "---" | nindent 0 -}}
+
+{{- $VMValues := $avm -}}
+{{- if not $VMValues.nameSuffix -}}
+  {{- $_ := set $VMValues "nameSuffix" $name -}}
+{{ end -}}
+{{- $_ := set $ "ObjectValues" (dict "appVolumeMounts" $VMValues) -}}
+
+{{ include "common.custom.mountpermissions.job" $  | nindent 0 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/library/common/templates/custom/_mountPermissionsJob.yaml
+++ b/library/common/templates/custom/_mountPermissionsJob.yaml
@@ -1,0 +1,63 @@
+{{/*
+This template serves as the blueprint for the mountPermissions job that is run 
+before chart installation.
+*/}}
+{{- define "common.custom.mountpermissions.job" -}}
+
+{{- $values := .Values.appVolumeMounts -}}
+{{- if hasKey . "ObjectValues" -}}
+  {{- with .ObjectValues.appVolumeMounts -}}
+    {{- $values = . -}}
+  {{- end -}}
+{{ end -}}
+{{- $JobName := include "common.names.fullname" . -}}
+{{- if hasKey $values "nameSuffix" -}}
+  {{- $JobName = printf "%v-%v" $JobName $values.nameSuffix -}}
+{{ end -}}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $JobName }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.controllerLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+   "helm.sh/hook": pre-install,pre-upgrade
+   "helm.sh/hook-weight": "-10"
+   "helm.sh/hook-delete-policy": hook-succeeded
+  {{- with .Values.controllerAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+      {{- include "common.labels.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: set-mount-permissions
+          image: "alpine:3.3"
+          command:
+          - /bin/sh
+          - -c
+          - |
+            chown -R {{ print .Values.PUID }}:{{ print .Values.PGID }} {{ print $values.mountPath }}
+          #args:
+          #  
+          #securityContext:
+          #  
+          volumeMounts:
+            {{- include "common.custom.configuredAppVolumeMounts" . | indent 12 }}
+      {{- with (include "common.controller.volumes" . | trim) }}
+      volumes:
+        {{- . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -99,7 +99,7 @@ probes:
     ## The spec field contains the values for the default livenessProbe.
     ## If you selected custom: true, this field holds the definition of the livenessProbe.
     spec:
-      initialDelaySeconds: 0
+      initialDelaySeconds: 30
       periodSeconds: 10
       timeoutSeconds: 10
       failureThreshold: 5
@@ -111,7 +111,7 @@ probes:
     ## The spec field contains the values for the default readinessProbe.
     ## If you selected custom: true, this field holds the definition of the readinessProbe.
     spec:
-      initialDelaySeconds: 0
+      initialDelaySeconds: 30
       periodSeconds: 10
       timeoutSeconds: 10
       failureThreshold: 5
@@ -123,11 +123,11 @@ probes:
     ## The spec field contains the values for the default startupProbe.
     ## If you selected custom: true, this field holds the definition of the startupProbe.
     spec:
-      initialDelaySeconds: 0
+      initialDelaySeconds: 5
       timeoutSeconds: 10
       ## This means it has a maximum of 5*30=150 seconds to start up before it fails
-      periodSeconds: 5
-      failureThreshold: 120
+      periodSeconds: 10
+      failureThreshold: 30
 
 service:
   enabled: true
@@ -454,7 +454,8 @@ addons:
 PUID: 568
 PGID: 568
 
-appAdditionalServicesEnabled: false
+fixMountPermissions: true
+# appAdditionalServicesEnabled: false
 # appAdditionalServices:
 #   api:
 #     enabled: false
@@ -490,6 +491,9 @@ appAdditionalServicesEnabled: false
 #     subPath: some-subpath
 #     hostPathEnabled: false
 #     hostPath: ""
+#     setPermissions: true
+
+#
 #   data:
 #     enabled: false
 #     emptyDir: false


### PR DESCRIPTION
**Description**

This PR aims to add a way of force-setting the mounted folder permissions on App install.
In contrast with init containers this pre-install solution has the benefit of not running a root init-container every run.

in the future PUID and PGID can also be used to automatically set the required settings for securityContext based containers.

So:
Fixes #128

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor of current code

**How Has This Been Tested?**

Automatic tests and unittests (new unittests to deal with PGID and PUID)


**Notes:**


**Checklist:**

- [] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works