### PR TITLE
Add PGID and PUID options

### DIFF
--- a/.test/charts/common-test_spec.rb
+++ b/.test/charts/common-test_spec.rb
@@ -41,8 +41,11 @@ class Test < ChartTest
     describe 'Environment settings' do
       it 'Check no environment variables' do
         values = {}
-        chart.value values        
-        assert_nil(resource('Deployment')['spec']['template']['spec']['containers'][0]['env'])
+        chart.value values
+        jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal 'PUID'
+        jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal 568
+		jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
+        jq('.spec.template.spec.containers[0].env[1].value', resource('Deployment')).must_equal 568
       end
 
       it 'set "static" environment variables' do
@@ -52,8 +55,12 @@ class Test < ChartTest
           }
         }
         chart.value values
-        jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal values[:env].keys[0].to_s
-        jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal values[:env].values[0].to_s
+        jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal 'PUID'
+        jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal 568
+		jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
+        jq('.spec.template.spec.containers[0].env[1].value', resource('Deployment')).must_equal 568
+        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal values[:env].keys[0].to_s
+        jq('.spec.template.spec.containers[0].env[2].value', resource('Deployment')).must_equal values[:env].values[0].to_s
       end
 
       it 'set "valueFrom" environment variables' do
@@ -67,8 +74,12 @@ class Test < ChartTest
           }
         }
         chart.value values
-        jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal values[:envValueFrom].keys[0].to_s
-        jq('.spec.template.spec.containers[0].env[0].valueFrom | keys[0]', resource('Deployment')).must_equal values[:envValueFrom].values[0].keys[0].to_s
+        jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal 'PUID'
+        jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal 568
+		jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
+        jq('.spec.template.spec.containers[0].env[1].value', resource('Deployment')).must_equal 568
+        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal values[:envValueFrom].keys[0].to_s
+        jq('.spec.template.spec.containers[0].env[2].valueFrom | keys[0]', resource('Deployment')).must_equal values[:envValueFrom].values[0].keys[0].to_s
       end
 
       it 'set "static" and "Dynamic/Tpl" environment variables' do
@@ -81,10 +92,14 @@ class Test < ChartTest
           }
         }
         chart.value values
-        jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal values[:env].keys[0].to_s
-        jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal values[:env].values[0].to_s
-        jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal values[:envTpl].keys[0].to_s
-        jq('.spec.template.spec.containers[0].env[1].value', resource('Deployment')).must_equal 'common-test-admin'
+        jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal 'PUID'
+        jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal 568
+		jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
+        jq('.spec.template.spec.containers[0].env[1].value', resource('Deployment')).must_equal 568
+        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal values[:env].keys[0].to_s
+        jq('.spec.template.spec.containers[0].env[2].value', resource('Deployment')).must_equal values[:env].values[0].to_s
+        jq('.spec.template.spec.containers[0].env[3].name', resource('Deployment')).must_equal values[:envTpl].keys[0].to_s
+        jq('.spec.template.spec.containers[0].env[3].value', resource('Deployment')).must_equal 'common-test-admin'
       end
       
       it 'set "Dynamic/Tpl" environment variables' do
@@ -94,8 +109,12 @@ class Test < ChartTest
           }
         }
         chart.value values
-        jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal values[:envTpl].keys[0].to_s
-        jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal 'common-test-admin'
+        jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal 'PUID'
+        jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal 568
+		jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
+        jq('.spec.template.spec.containers[0].env[1].value', resource('Deployment')).must_equal 568
+        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal values[:envTpl].keys[0].to_s
+        jq('.spec.template.spec.containers[0].env[2].value', resource('Deployment')).must_equal 'common-test-admin'
       end
     end
 

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for TrueCharts
 type: library
-version: 1.0.0
+version: 1.1.0
 kubeVersion: ">=1.16.0-0"
 # upstream_version: 3.0.1
 keywords:

--- a/library/common/templates/lib/controller/_container.tpl
+++ b/library/common/templates/lib/controller/_container.tpl
@@ -15,28 +15,32 @@ The main container included in the controller.
   securityContext:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if or .Values.env .Values.envTpl .Values.envValueFrom }}
   env:
+    - name: PUID
+      value: {{ .Values.PUID }}
+    - name: PGID
+      value: {{ .Values.PGID }}
+  {{- if or .Values.env .Values.envTpl .Values.envValueFrom .Values.envVariable }}
   {{- range $envVariable := .Values.environmentVariables }}
   {{- if and $envVariable.name $envVariable.value }}
     - name: {{ $envVariable.name }}
-    value: {{ $envVariable.value | quote }}
+      value: {{ $envVariable.value | quote }}
   {{- else }}
     {{- fail "Please specify name/value for environment variable" }}
   {{- end }}
   {{- end}}
   {{- range $key, $value := .Values.env }}
-  - name: {{ $key }}
-    value: {{ $value | quote }}
+    - name: {{ $key }}
+      value: {{ $value | quote }}
   {{- end }}
   {{- range $key, $value := .Values.envTpl }}
-  - name: {{ $key }}
-    value: {{ tpl $value $ | quote }}
+    - name: {{ $key }}
+      value: {{ tpl $value $ | quote }}
   {{- end }}
   {{- range $key, $value := .Values.envValueFrom }}
-  - name: {{ $key }}
-    valueFrom: 
-      {{- $value | toYaml | nindent 6 }}
+    - name: {{ $key }}
+      valueFrom: 
+        {{- $value | toYaml | nindent 8 }}
   {{- end }}
   {{- end }}
   {{- with .Values.envFrom }}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -32,6 +32,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+
 env: {}
   # TZ: UTC
 
@@ -449,6 +450,9 @@ addons:
 
 
 ## TrueCharts Specific
+
+PUID: 568
+PGID: 568
 
 appAdditionalServicesEnabled: false
 # appAdditionalServices:


### PR DESCRIPTION
- Adds PGID as a values.yaml setting that sets PGID env-var
- Adds PUID as a values.yaml settings that sets PGID env-var
- Sets default PGID and PUID for ALL containers to 568
- Adjusts Common Unit test accordingly
(both can also in the future be used to set securityContext based containers or file permissions)
ove my fix is effective or that my feature works

Fixes #135