### PR TITLE
Makes common correctly process TZ, UMASK and lists of env-vars

### DIFF
--- a/.test/charts/common-test_spec.rb
+++ b/.test/charts/common-test_spec.rb
@@ -44,8 +44,10 @@ class Test < ChartTest
         chart.value values
         jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal 'PUID'
         jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal "568"
-		jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
+        jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
         jq('.spec.template.spec.containers[0].env[1].value', resource('Deployment')).must_equal "568"
+        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal 'UMASK'
+        jq('.spec.template.spec.containers[0].env[2].value', resource('Deployment')).must_equal "002"
       end
 
       it 'set "static" environment variables' do
@@ -57,10 +59,12 @@ class Test < ChartTest
         chart.value values
         jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal 'PUID'
         jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal "568"
-		jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
+        jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
         jq('.spec.template.spec.containers[0].env[1].value', resource('Deployment')).must_equal "568"
-        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal values[:env].keys[0].to_s
-        jq('.spec.template.spec.containers[0].env[2].value', resource('Deployment')).must_equal values[:env].values[0].to_s
+        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal 'UMASK'
+        jq('.spec.template.spec.containers[0].env[2].value', resource('Deployment')).must_equal "002"
+        jq('.spec.template.spec.containers[0].env[3].name', resource('Deployment')).must_equal values[:env].keys[0].to_s
+        jq('.spec.template.spec.containers[0].env[3].value', resource('Deployment')).must_equal values[:env].values[0].to_s
       end
 
       it 'set "valueFrom" environment variables' do
@@ -76,10 +80,12 @@ class Test < ChartTest
         chart.value values
         jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal 'PUID'
         jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal "568"
-		jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
+        jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
         jq('.spec.template.spec.containers[0].env[1].value', resource('Deployment')).must_equal "568"
-        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal values[:envValueFrom].keys[0].to_s
-        jq('.spec.template.spec.containers[0].env[2].valueFrom | keys[0]', resource('Deployment')).must_equal values[:envValueFrom].values[0].keys[0].to_s
+        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal 'UMASK'
+        jq('.spec.template.spec.containers[0].env[2].value', resource('Deployment')).must_equal "002"
+        jq('.spec.template.spec.containers[0].env[3].name', resource('Deployment')).must_equal values[:envValueFrom].keys[0].to_s
+        jq('.spec.template.spec.containers[0].env[3].valueFrom | keys[0]', resource('Deployment')).must_equal values[:envValueFrom].values[0].keys[0].to_s
       end
 
       it 'set "static" and "Dynamic/Tpl" environment variables' do
@@ -94,12 +100,14 @@ class Test < ChartTest
         chart.value values
         jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal 'PUID'
         jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal "568"
-		jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
+        jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
         jq('.spec.template.spec.containers[0].env[1].value', resource('Deployment')).must_equal "568"
-        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal values[:env].keys[0].to_s
-        jq('.spec.template.spec.containers[0].env[2].value', resource('Deployment')).must_equal values[:env].values[0].to_s
-        jq('.spec.template.spec.containers[0].env[3].name', resource('Deployment')).must_equal values[:envTpl].keys[0].to_s
-        jq('.spec.template.spec.containers[0].env[3].value', resource('Deployment')).must_equal 'common-test-admin'
+        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal 'UMASK'
+        jq('.spec.template.spec.containers[0].env[2].value', resource('Deployment')).must_equal "002"
+        jq('.spec.template.spec.containers[0].env[3].name', resource('Deployment')).must_equal values[:env].keys[0].to_s
+        jq('.spec.template.spec.containers[0].env[3].value', resource('Deployment')).must_equal values[:env].values[0].to_s
+        jq('.spec.template.spec.containers[0].env[4].name', resource('Deployment')).must_equal values[:envTpl].keys[0].to_s
+        jq('.spec.template.spec.containers[0].env[4].value', resource('Deployment')).must_equal 'common-test-admin'
       end
       
       it 'set "Dynamic/Tpl" environment variables' do
@@ -111,10 +119,12 @@ class Test < ChartTest
         chart.value values
         jq('.spec.template.spec.containers[0].env[0].name', resource('Deployment')).must_equal 'PUID'
         jq('.spec.template.spec.containers[0].env[0].value', resource('Deployment')).must_equal "568"
-		jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
+        jq('.spec.template.spec.containers[0].env[1].name', resource('Deployment')).must_equal 'PGID'
         jq('.spec.template.spec.containers[0].env[1].value', resource('Deployment')).must_equal "568"
-        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal values[:envTpl].keys[0].to_s
-        jq('.spec.template.spec.containers[0].env[2].value', resource('Deployment')).must_equal 'common-test-admin'
+        jq('.spec.template.spec.containers[0].env[2].name', resource('Deployment')).must_equal 'UMASK'
+        jq('.spec.template.spec.containers[0].env[2].value', resource('Deployment')).must_equal "002"
+        jq('.spec.template.spec.containers[0].env[3].name', resource('Deployment')).must_equal values[:envTpl].keys[0].to_s
+        jq('.spec.template.spec.containers[0].env[3].value', resource('Deployment')).must_equal 'common-test-admin'
       end
     end
 

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: Function library for TrueCharts
 type: library
-version: 1.2.0
+version: 1.3.0
 
 kubeVersion: ">=1.16.0-0"
 # upstream_version: 3.0.1

--- a/library/common/templates/lib/controller/_container.tpl
+++ b/library/common/templates/lib/controller/_container.tpl
@@ -20,7 +20,13 @@ The main container included in the controller.
       value: {{ .Values.PUID | quote }}
     - name: PGID
       value: {{ .Values.PGID | quote }}
-  {{- if or .Values.env .Values.envTpl .Values.envValueFrom .Values.envVariable }}
+    - name: UMASK
+      value: {{ .Values.UMASK | quote }}
+  {{- if .Values.timezone }}
+    - name: TZ
+      value: {{ .Values.timezone | quote }}
+  {{- end }}
+  {{- if or .Values.env .Values.envTpl .Values.envValueFrom .Values.envVariable .Values.environmentVariables }}
   {{- range $envVariable := .Values.environmentVariables }}
   {{- if and $envVariable.name $envVariable.value }}
     - name: {{ $envVariable.name }}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -453,6 +453,7 @@ addons:
 
 PUID: 568
 PGID: 568
+UMASK: "002"
 
 fixMountPermissions: true
 # appAdditionalServicesEnabled: false


### PR DESCRIPTION
**Description**

This PR fixes the common-chart backend processing the timezone setting in questions.yaml
It also adds the umask and fixes the processing of lists of environment variables

Fixes #126
Fixes: #135

**Type of change**

- [X] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**



**Notes:**

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works