### PR TITLE
Abstract away certificate creation to support ingress

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: common
-version: 1.4.0
+version: 1.5.0
 # upstream_version: 3.0.1
 # appVersion:
 description: Function library for TrueCharts

--- a/library/common/templates/_all.tpl
+++ b/library/common/templates/_all.tpl
@@ -37,5 +37,4 @@ Main entrypoint for the common library chart. It will render all underlying temp
   {{- print "---" | nindent 0 -}}
   {{ include "common.appIngress" .  | nindent 0 }}
   {{ include "common.storage.permissions" .  | nindent 0 }}
-  {{ include "common.resources.cert.secret" . | nindent 0 }}
 {{- end -}}

--- a/library/common/templates/classes/ingress/_appIngressHTTP.tpl
+++ b/library/common/templates/classes/ingress/_appIngressHTTP.tpl
@@ -51,7 +51,7 @@ spec:
       {{ else if eq $values.certType "existingcert" }}
       secretName: {{ $values.existingcert }}
       {{ else if eq $values.certType "ixcert" }}
-      secretName: {{ include "common.names.fullname" . }}-ix-cert
+      secretName: {{ $IngressName }}
       {{ else if eq $values.certType "wildcard" }}
       secretName: wildcardcert
       {{ else }}

--- a/library/common/templates/classes/ingress/_appIngressTCP.tpl
+++ b/library/common/templates/classes/ingress/_appIngressTCP.tpl
@@ -52,7 +52,7 @@ spec:
     {{ else if eq $values.certType "existingcert" }}
     secretName: {{ $values.existingcert }}
 	{{ else if eq $values.certType "ixcert" }}
-    secretName: {{ include "common.names.fullname" . }}-ix-cert
+    secretName: {{ $IngressName }}
     {{ else if eq $values.certType "wildcard" }}
     secretName: wildcardcert
     {{ else }}

--- a/library/common/templates/lib/resources/_appingress.tpl
+++ b/library/common/templates/lib/resources/_appingress.tpl
@@ -11,7 +11,7 @@ Renders the additional ingress objects from appIngress
           {{- if not $ingressValues.nameSuffix -}}
             {{- $_ := set $ingressValues "nameSuffix" $name -}}
           {{ end -}}
-          {{- $_ := set $ "ObjectValues" (dict "appIngress" $ingressValues) -}}
+		  {{- $_ := set $ "ObjectValues" (dict "appIngress" $ingressValues) -}}
           {{- if $ingressValues.type -}}
             {{- if eq $ingressValues.type "UDP" -}}
               {{- include "common.classes.appIngressUDP" $ }}
@@ -29,6 +29,9 @@ Renders the additional ingress objects from appIngress
               {{- include "common.classes.appAuthForward" $ }}
             {{- end }}
           {{- end }}
+		  {{- $_ := set $ "ObjectValues" (dict "certHolder" $ingressValues) -}}
+		  {{- print ("---") | nindent 0 -}}
+		  {{- include "common.resources.cert.secret" $ }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/library/common/templates/lib/resources/_certHelpers.tpl
+++ b/library/common/templates/lib/resources/_certHelpers.tpl
@@ -2,9 +2,9 @@
 Retrieve true/false if certificate is configured
 */}}
 {{- define "common.resources.cert.available" -}}
-{{- if .Values.certificate -}}
+{{- if .ObjectValues.certHolder.certificate -}}
 {{- $values := (. | mustDeepCopy) -}}
-{{- $_ := set $values "commonCertOptions" (dict "certKeyName" $values.Values.certificate) -}}
+{{- $_ := set $values "commonCertOptions" (dict "certKeyName" $values.ObjectValues.certHolder.certificate) -}}
 {{- template "common.resources.cert_present" $values -}}
 {{- else -}}
 {{- false -}}
@@ -17,7 +17,7 @@ Retrieve public key of certificate
 */}}
 {{- define "common.resources.cert.publicKey" -}}
 {{- $values := (. | mustDeepCopy) -}}
-{{- $_ := set $values "commonCertOptions" (dict "certKeyName" $values.Values.certificate "publicKey" true) -}}
+{{- $_ := set $values "commonCertOptions" (dict "certKeyName" $values.ObjectValues.certHolder.certificate "publicKey" true) -}}
 {{ include "common.resources.cert" $values }}
 {{- end -}}
 
@@ -27,6 +27,6 @@ Retrieve private key of certificate
 */}}
 {{- define "common.resources.cert.privateKey" -}}
 {{- $values := (. | mustDeepCopy) -}}
-{{- $_ := set $values "commonCertOptions" (dict "certKeyName" $values.Values.certificate) -}}
+{{- $_ := set $values "commonCertOptions" (dict "certKeyName" $values.ObjectValues.certHolder.certificate) -}}
 {{ include "common.resources.cert" $values }}
 {{- end -}}

--- a/library/common/templates/lib/resources/_certSecret.yaml
+++ b/library/common/templates/lib/resources/_certSecret.yaml
@@ -1,14 +1,23 @@
 {{- define "common.resources.cert.secret" -}}
-{{ if eq (include "common.resources.cert.available" .) "true" }}
----
+
+
+{{- $secretName := include "common.names.fullname" . -}}
+
+{{- if .ObjectValues.certHolder -}}
+  {{- $secretName = printf "%v-%v" $secretName .ObjectValues.certHolder.nameSuffix -}}
+{{ else }}
+  {{- $_ := set $ "ObjectValues" (dict "certHolder" .Values) -}}
+{{ end -}}
+
+{{- if eq (include "common.resources.cert.available" $ ) "true" -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.names.fullname" . }}-ix-cert
+  name: {{ $secretName }}
   labels: {{ include "common.labels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ (include "common.resources.cert.publicKey" .) | toString | b64enc | quote }}
-  tls.key: {{ (include "common.resources.cert.privateKey" .) | toString | b64enc | quote }}
-{{ end }}
-{{- end }}
+  tls.crt: {{ (include "common.resources.cert.publicKey" $ ) | toString | b64enc | quote }}
+  tls.key: {{ (include "common.resources.cert.privateKey" $ ) | toString | b64enc | quote }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Goal of this PR is to enable us to use different IX-Certificates for different objects. For example: Different Certificates for different Ingresses or one for ingress and one for a device specific function.

This gets increasingly important when you take into account the fact Traefik **requires** the domain of the certificate to match the Ingress Host.

The current design from IX focusses around providing one certificate for each App. This would certainly work, but adding a little extra flexibility might go a long way in the future.

Fixes # <!--(issue)-->

**Type of change**

- [x] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
