### PR TITLE
Cleanup storage and add storage unittests

### DIFF
--- a/.github/docs/development/storage.md
+++ b/.github/docs/development/storage.md
@@ -90,7 +90,7 @@ It should always be included in any App, to give users the option to customise t
 ##### Example
 
 ```
-  - variable: appExtraVolumeMounts
+  - variable: additionalAppVolumeMounts
     label: "Custom app storage"
     group: "Storage"
     schema:

--- a/.tools/tests/charts/common-test_spec.rb
+++ b/.tools/tests/charts/common-test_spec.rb
@@ -215,5 +215,48 @@ class Test < ChartTest
         jq('.spec.volumeClaimTemplates[0].spec.storageClassName', resource('StatefulSet')).must_equal values[:volumeClaimTemplates][0][:storageClass]
       end
     end
+
+	describe 'appVolumeMounts' do
+      default_name_1 = 'test1'
+	  default_name_2 = 'test2'
+      default_mountPath_1 = '/test1'
+	  default_mountPath_2 = '/test2'
+	  empty_dir = {}
+	  path = '/tmp'
+
+      it 'appVolumeMounts creates VolumeMounts' do
+        jq('.spec.template.spec.containers[0].volumeMounts[0].name', resource('Deployment')).must_equal default_name_1
+		jq('.spec.template.spec.containers[0].volumeMounts[1].name', resource('Deployment')).must_equal default_name_2
+		jq('.spec.template.spec.containers[0].volumeMounts[0].mountPath', resource('Deployment')).must_equal default_mountPath_1
+		jq('.spec.template.spec.containers[0].volumeMounts[1].mountPath', resource('Deployment')).must_equal default_mountPath_2
+      end
+
+      it 'appVolumeMounts creates Volumes' do
+		jq('.spec.template.spec.volumes[0].emptyDir', resource('Deployment')).must_equal empty_dir
+		jq('.spec.template.spec.volumes[1].hostPath.path', resource('Deployment')).must_equal path
+      end
+    end
+
+	describe 'additionalAppVolumeMounts' do
+      default_name_3 = 'test3'
+	  default_name_4 = 'test4'
+      default_mountPath_3 = '/test3'
+	  default_mountPath_4 = '/test4'
+	  empty_dir = {}
+	  path = '/tmp'
+
+      it 'additionalAppVolumeMounts creates VolumeMounts' do
+        jq('.spec.template.spec.containers[0].volumeMounts[2].name', resource('Deployment')).must_equal default_name_3
+		jq('.spec.template.spec.containers[0].volumeMounts[3].name', resource('Deployment')).must_equal default_name_4
+		jq('.spec.template.spec.containers[0].volumeMounts[2].mountPath', resource('Deployment')).must_equal default_mountPath_3
+		jq('.spec.template.spec.containers[0].volumeMounts[3].mountPath', resource('Deployment')).must_equal default_mountPath_4
+      end
+
+      it 'additionalAppVolumeMounts creates Volumes' do
+		jq('.spec.template.spec.volumes[2].emptyDir', resource('Deployment')).must_equal empty_dir
+		jq('.spec.template.spec.volumes[3].hostPath.path', resource('Deployment')).must_equal path
+      end
+    end
+
   end
 end

--- a/library/common-test/values.yaml
+++ b/library/common-test/values.yaml
@@ -10,36 +10,38 @@ service:
 ingress:
   enabled: true
 
+# these values and names are set specifically with the unittests in mind.
 fixMountPermissions: false
 appVolumeMounts:
-  data:
+  test1:
     enabled: true
     emptyDir: true
-    datasetName: "data"
-    mountPath: "/data"
+    datasetName: "test1"
+    mountPath: "/test1"
     hostPathEnabled: false
     hostPath: ""
-  test:
+  test2:
     enabled: true
     emptyDir: false
-    datasetName: "test"
-    mountPath: "/test"
+    datasetName: "test2"
+    mountPath: "/test2"
     hostPathEnabled: true
     hostPath: "/tmp"
 
-appExtraVolumeMounts:
-  - name: "extratest1"
+# these values and names are set specifically with the unittests in mind.
+additionalAppVolumeMounts:
+  - name: "test3"
     enabled: true
     emptyDir: true
-    datasetName: "extratest1"
-    mountPath: "/extratest1"
+    datasetName: "test3"
+    mountPath: "/test3"
     hostPathEnabled: false
     hostPath: ""
-  - name: "extratest2"
+  - name: "test4"
     enabled: true
     emptyDir: false
-    datasetName: "extratest2"
-    mountPath: "/extratest2"
+    datasetName: "test4"
+    mountPath: "/test4"
     hostPathEnabled: true
     hostPath: "/tmp"
 

--- a/library/common/templates/lib/storage/_appStorage.tpl
+++ b/library/common/templates/lib/storage/_appStorage.tpl
@@ -49,12 +49,12 @@ Get all volumes configuration
 {{- define "common.storage.allAppVolumes" -}}
 
 {{- $volDict := dict "volMounts" .Values.appVolumeMounts "ixVolumes" .Values.ixVolumes -}}
-{{- $volExtraDict := dict "volMounts" .Values.appExtraVolumeMounts "ixVolumes" .Values.ixVolumes -}}
+{{- $volExtraDict := dict "volMounts" .Values.additionalAppVolumeMounts "ixVolumes" .Values.ixVolumes -}}
 
 {{- if .Values.appVolumeMounts -}}
 {{- include "common.storage.configureAppVolumes" $volDict | nindent 0 -}}
 {{- end -}}
-{{- if .Values.appExtraVolumeMounts -}}
+{{- if .Values.additionalAppVolumeMounts -}}
 {{- include "common.storage.configureAppVolumes" $volExtraDict | nindent 0 -}}
 {{- end -}}
 
@@ -69,8 +69,8 @@ Get all container volume moutns configuration
 {{- if .Values.appVolumeMounts -}}
 {{- include "common.storage.configureAppVolumeMountsInContainer" .Values.appVolumeMounts | nindent 0 -}}
 {{- end -}}
-{{- if .Values.appExtraVolumeMounts -}}
-{{- include "common.storage.configureAppVolumeMountsInContainer" .Values.appExtraVolumeMounts | nindent 0 -}}
+{{- if .Values.additionalAppVolumeMounts -}}
+{{- include "common.storage.configureAppVolumeMountsInContainer" .Values.additionalAppVolumeMounts | nindent 0 -}}
 {{- end -}}
 
 {{- end -}}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -328,7 +328,7 @@ fixMountPermissions: true
 #     hostPath: ""
 #     setPermissions: true
 
-# appExtraVolumeMounts:
+# additionalAppVolumeMounts:
 #   - name: "data"
 #     enabled: false
 #     emptyDir: false


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

adds some initial appVolumeMounts storage test
and renames appExtraVolumeMounts to additionalAppVolumeMounts

Storage test contain basic checks if the values in values.yaml of common-test, are present in the resulting chart.
It does not do change-checking, but it does test if both the VolumeMounts and Volumes are present as they should.

This should at least prevent any changes from passing that prevent storage from mounting.

Fixes # <!--(issue)-->

**Type of change**

- [ ] Feature/App addition
- [ ] Bugfix
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests to this description that prove my fix is effective or that my feature works
