### PR TITLE
Cleanup versioning and add auto-updater

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,15 +8,16 @@
   "rebaseWhen": "conflicted",
   "prConcurrentLimit": 5,
   "helm-values": {
-    "enabled": false
+    "fileMatch": ["charts/.+/.+/.*_values\\.yaml$"]
   },
   "helmv3": {
     "fileMatch": ["charts/.+/.+/Chart\\.yaml$"]
   },
   "packageRules": [
-    // Setup datasources
+    // Setup datasources for dep updates
     {
       "datasources": ["helm"],
+	  "matchManagers": ["helmv3"],
       "commitMessageTopic": "Helm chart {{depName}}",
       "separateMinorPatch": true
     },
@@ -78,6 +79,60 @@
       "schedule": [
         "every 1 months on the first day of the month"
       ]
+    },
+    // Setup datasources tag updates
+    {
+      "datasources": ["helm"],
+	    "matchManagers": ["helm-values"],
+      "commitMessageTopic": "Helm chart {{depName}}"
+    },
+    //
+    // Tag updates for semantic tags
+    //
+    {
+      "commitMessagePrefix": "[{{{parentDir}}}]",
+      "branchTopic": "{{{parentDir}}}-{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}",
+      "updateTypes": ["major"],
+      "bumpVersion": "major",
+      "labels": ["tag/major"]
+    },
+    {
+      "updateTypes": ["minor"],
+      "bumpVersion": "patch",
+      "labels": ["tag/minor"],
+      "groupName": ["minor"]
+    },
+    {
+      "updateTypes": ["patch", "minor"],
+      "bumpVersion": "patch",
+      "labels": ["tag/patch"],
+      "groupName": ["patch"]
+    },
+    //
+    // Tag updates for linuxserver two-three digit versions
+    //
+    {
+      "packagePatterns": ["^linuxserver\\/"],
+      "versionScheme": "regex:^(?<compatibility>.*?(\\d+\\.)??)(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d+)?(-r?p?\\d)?$"
+    },
+    {
+      "commitMessagePrefix": "[{{{parentDir}}}]",
+      "branchTopic": "{{{parentDir}}}-{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}",
+      "updateTypes": ["major"],
+      "bumpVersion": "major",
+      "labels": ["tag/major"]
+    },
+    {
+      "updateTypes": ["minor"],
+      "bumpVersion": "patch",
+      "labels": ["tag/minor"],
+      "groupName": ["minor"]
+    },
+    {
+      "updateTypes": ["patch", "minor"],
+      "bumpVersion": "patch",
+      "labels": ["tag/patch"],
+      "groupName": ["patch"]
     }
   ]
 }

--- a/charts/bazarr/2.0.0/Chart.yaml
+++ b/charts/bazarr/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: bazarr
 version: 2.0.0
 upstream_version: 5.2.1
-appVersion: v0.9.0.5
+appVersion: "auto"
 description: Bazarr is a companion application to Bazarr and Radarr. It manages and downloads subtitles based on your requirements
 type: application
 deprecated: false

--- a/charts/calibre-web/2.0.0/Chart.yaml
+++ b/charts/calibre-web/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: calibre-web
 version: 2.0.0
 upstream_version: 4.3.1
-appVersion: 0.6.9
+appVersion: "auto"
 description: Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
 type: application
 deprecated: false

--- a/charts/collabora-online/2.0.0/Chart.yaml
+++ b/charts/collabora-online/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: collabora-online
 version: 2.0.0
 # upstream_version:
-appVersion: 6.4.6.1
+appVersion: "auto"
 description: Collabora Online Development Edition – an awesome, Online Office suite image suitable for home use.
 type: application
 deprecated: false

--- a/charts/deluge/2.0.0/Chart.yaml
+++ b/charts/deluge/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: deluge
 version: 2.0.0
 upstream_version: 1.1.1
-appVersion: v2.0.3-2201906121747
+appVersion: "latest"
 description: Deluge is a torrent download client
 type: application
 deprecated: false

--- a/charts/deluge/2.0.0/ix_values.yaml
+++ b/charts/deluge/2.0.0/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: linuxserver/deluge
   pullPolicy: IfNotPresent
-  tag: version-2.0.3-2201906121747ubuntu18.04.1
+  tag: latest
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/deluge/2.0.0/test_values.yaml
+++ b/charts/deluge/2.0.0/test_values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: linuxserver/deluge
   pullPolicy: IfNotPresent
-  tag: version-2.0.3-2201906121747ubuntu18.04.1
+  tag: latest
 
 strategy:
   type: Recreate

--- a/charts/esphome/2.0.0/Chart.yaml
+++ b/charts/esphome/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: esphome
 version: 2.0.0
 upstream_version: 4.3.1
-appVersion: 1.15.3
+appVersion: "auto"
 description: ESPHome is a system to control your ESP8266/ESP32 by simple yet powerful configuration files and control them remotely through Home Automation systems.
 type: application
 deprecated: false

--- a/charts/freshrss/2.0.0/Chart.yaml
+++ b/charts/freshrss/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: freshrss
 version: 2.0.0
 upstream_version: 2.3.1
-appVersion: 1.17.0
+appVersion: "auto"
 description: FreshRSS is a self-hosted RSS feed aggregator
 type: application
 deprecated: false

--- a/charts/gaps/2.0.0/Chart.yaml
+++ b/charts/gaps/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: gaps
 version: 2.0.0
 upstream_version: 1.1.1
-appVersion: latest
+appVersion: "auto"
 description: Gaps searches through your Plex Server or local folders for all movies, then queries for known movies in the same collection.
 type: application
 deprecated: false

--- a/charts/gaps/2.0.0/ix_values.yaml
+++ b/charts/gaps/2.0.0/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: housewrecker/gaps
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: v0.8.8
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/gaps/2.0.0/test_values.yaml
+++ b/charts/gaps/2.0.0/test_values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: housewrecker/gaps
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: v0.8.8
 
 strategy:
   type: Recreate

--- a/charts/grocy/2.0.0/Chart.yaml
+++ b/charts/grocy/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: grocy
 version: 2.0.0
 upstream_version: 4.3.1
-appVersion: v2.7.1
+appVersion: "auto"
 description: ERP beyond your fridge - grocy is a web-based self-hosted groceries & household management solution for your home
 type: application
 deprecated: false

--- a/charts/handbrake/2.0.0/Chart.yaml
+++ b/charts/handbrake/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: handbrake
 version: 2.0.0
 # upstream_version:
-appVersion: 1.23.1
+appVersion: "auto"
 description: HandBrake is a tool for converting video from nearly any format to a selection of modern, widely supported codecs.
 type: application
 deprecated: false

--- a/charts/handbrake/2.0.0/ix_values.yaml
+++ b/charts/handbrake/2.0.0/ix_values.yaml
@@ -8,6 +8,7 @@ image:
   repository: jlesage/handbrake
   tag: v1.23.1
   pullPolicy: IfNotPresent
+
 #All values here are set as the docker defaults.
 envTpl:
 # Permissions Settings

--- a/charts/heimdall/2.0.0/Chart.yaml
+++ b/charts/heimdall/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: heimdall
 version: 2.0.0
 upstream_version: 4.1.1
-appVersion: 2.2.2
+appVersion: "auto"
 description: An Application dashboard and launcher
 type: application
 deprecated: false

--- a/charts/home-assistant/2.0.0/Chart.yaml
+++ b/charts/home-assistant/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: home-assistant
 version: 2.0.0
 upstream_version: 5.3.0
-appVersion: 2021.2.2
+appVersion: "auto"
 description: home-assistant App for TrueNAS SCALE
 type: application
 deprecated: false

--- a/charts/jackett/2.0.0/Chart.yaml
+++ b/charts/jackett/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: jackett
 version: 2.0.0
 upstream_version: 7.0.1
-appVersion: version-v0.17.153
+appVersion: "auto"
 description: API Support for your favorite torrent trackers.
 type: application
 deprecated: false

--- a/charts/jellyfin/2.0.0/Chart.yaml
+++ b/charts/jellyfin/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: jellyfin
 version: 2.0.0
 upstream_version: 4.2.1
-appVersion: 10.6.4
+appVersion: "auto"
 description: Jellyfin is a Free Software Media System
 type: application
 deprecated: false

--- a/charts/kms/2.0.0/Chart.yaml
+++ b/charts/kms/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: kms
 version: 2.0.0
 # upstream_version:
-appVersion: latest
+appVersion: "auto"
 description: Private Windows Activation Server for development and testing
 type: application
 deprecated: false

--- a/charts/lazylibrarian/2.0.0/Chart.yaml
+++ b/charts/lazylibrarian/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: lazylibrarian
 version: 2.0.0
 upstream_version: 2.1.0
-appVersion: 1.7.2
+appVersion: "latest"
 description: Get all your books, like series with Sonarr...
 type: application
 deprecated: false

--- a/charts/lazylibrarian/2.0.0/ix_values.yaml
+++ b/charts/lazylibrarian/2.0.0/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: linuxserver/lazylibrarian
   pullPolicy: IfNotPresent
-  tag: version-047f91af
+  tag: latest
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/lazylibrarian/2.0.0/test_values.yaml
+++ b/charts/lazylibrarian/2.0.0/test_values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: linuxserver/lazylibrarian
   pullPolicy: IfNotPresent
-  tag: version-047f91af
+  tag: latest
 
 strategy:
   type: Recreate

--- a/charts/lidarr/2.0.0/Chart.yaml
+++ b/charts/lidarr/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: lidarr
 version: 2.0.0
 upstream_version: 7.1.0
-appVersion: 0.8.0.1886
+appVersion: "auto"
 description: Looks and smells like Sonarr but made for music
 type: application
 deprecated: false

--- a/charts/lychee/2.0.0/Chart.yaml
+++ b/charts/lychee/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: lychee
 version: 2.0.0
 upstream_version: 2.3.1
-appVersion: 4.0.8
+appVersion: "auto"
 description: Lychee is a free photo-management tool, which runs on your server or web-space
 type: application
 deprecated: false

--- a/charts/navidrome/2.0.0/Chart.yaml
+++ b/charts/navidrome/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: navidrome
 version: 2.0.0
 upstream_version: 2.3.1
-appVersion: 0.39.0
+appVersion: "auto"
 description: Navidrome is an open source web-based music collection server and streamer
 type: application
 deprecated: false

--- a/charts/node-red/2.0.0/Chart.yaml
+++ b/charts/node-red/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: node-red
 version: 2.0.0
 upstream_version: 5.2.1
-appVersion: 1.2.5
+appVersion: "auto"
 description: Node-RED is low-code programming for event-driven applications
 type: application
 deprecated: false

--- a/charts/nzbget/2.0.0/Chart.yaml
+++ b/charts/nzbget/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: nzbget
 version: 2.0.0
 upstream_version: 7.3.1
-appVersion: v21.0
+appVersion: "auto"
 description: NZBGet is a Usenet downloader client
 type: application
 deprecated: false

--- a/charts/nzbhydra/2.0.0/Chart.yaml
+++ b/charts/nzbhydra/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: nzbhydra
 version: 2.0.0
 upstream_version: 5.3.1
-appVersion: v3.8.1
+appVersion: "auto"
 description: Usenet meta search
 type: application
 deprecated: false

--- a/charts/nzbhydra/2.0.0/ix_values.yaml
+++ b/charts/nzbhydra/2.0.0/ix_values.yaml
@@ -8,6 +8,7 @@ image:
   repository: linuxserver/nzbhydra2
   pullPolicy: IfNotPresent
   tag: version-v3.8.1
+
 probes:
   liveness:
     custom: true

--- a/charts/ombi/2.0.0/Chart.yaml
+++ b/charts/ombi/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: ombi
 version: 2.0.0
 upstream_version: 8.0.1
-appVersion: 4.0.681
+appVersion: "auto"
 description: Want a Movie or TV Show on Plex or Emby? Use Ombi!
 type: application
 deprecated: false

--- a/charts/organizr/2.0.0/Chart.yaml
+++ b/charts/organizr/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: organizr
 version: 2.0.0
 upstream_version: 3.2.1
-appVersion: latest
+appVersion: "latest"
 description: HTPC/Homelab Services Organizer
 type: application
 deprecated: false

--- a/charts/qbittorrent/2.0.0/Chart.yaml
+++ b/charts/qbittorrent/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: qbittorrent
 version: 2.0.0
 upstream_version: 7.2.1
-appVersion: 4.3.0
+appVersion: "latest"
 description: qBittorrent is a cross-platform free and open-source BitTorrent client
 type: application
 deprecated: false

--- a/charts/qbittorrent/2.0.0/ix_values.yaml
+++ b/charts/qbittorrent/2.0.0/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: linuxserver/qbittorrent
   pullPolicy: IfNotPresent
-  tag: version-4.3.0202010181232-7086-1c663adeeubuntu18.04.1
+  tag: latest
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/qbittorrent/2.0.0/test_values.yaml
+++ b/charts/qbittorrent/2.0.0/test_values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: linuxserver/qbittorrent
   pullPolicy: IfNotPresent
-  tag: version-4.3.0202010181232-7086-1c663adeeubuntu18.04.1
+  tag: latest
 
 strategy:
   type: Recreate

--- a/charts/radarr/2.0.0/Chart.yaml
+++ b/charts/radarr/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: radarr
 version: 2.0.0
 upstream_version: 9.1.0
-appVersion: "version-3.0.0.3989"
+appVersion: "auto"
 description: A fork of Sonarr to work with movies à la Couchpotato
 type: application
 deprecated: false

--- a/charts/radarr/2.0.0/ix_values.yaml
+++ b/charts/radarr/2.0.0/ix_values.yaml
@@ -8,6 +8,7 @@ image:
   repository: linuxserver/radarr
   pullPolicy: IfNotPresent
   tag: version-3.0.0.3989
+
 probes:
   liveness:
     enabled: true

--- a/charts/readarr/2.0.0/Chart.yaml
+++ b/charts/readarr/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: readarr
 version: 2.0.0
 upstream_version: 2.1.0
-appversion: "nightly"
+appVersion: "nightly"
 description: A fork of Radarr to work with Books & AudioBooks
 type: application
 deprecated: false

--- a/charts/sabnzbd/2.0.0/Chart.yaml
+++ b/charts/sabnzbd/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: sabnzbd
 version: 2.0.0
 upstream_version: 5.0.1
-appVersion: 3.1.0
+appVersion: "auto"
 description: Free and easy binary newsreader
 type: application
 deprecated: false

--- a/charts/sonarr/2.0.0/Chart.yaml
+++ b/charts/sonarr/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: sonarr
 version: 2.0.0
 upstream_version: 9.1.0
-appVersion: "version-3.0.4.993"
+appVersion: "auto"
 description: Smart PVR for newsgroup and bittorrent users
 type: application
 deprecated: false

--- a/charts/sonarr/2.0.0/ix_values.yaml
+++ b/charts/sonarr/2.0.0/ix_values.yaml
@@ -8,6 +8,7 @@ image:
   repository: linuxserver/sonarr
   pullPolicy: IfNotPresent
   tag: version-3.0.4.993
+
 probes:
     liveness:
     enabled: true

--- a/charts/tautulli/2.0.0/Chart.yaml
+++ b/charts/tautulli/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: tautulli
 version: 2.0.0
 upstream_version: 7.0.1
-appVersion: "v2.6.6"
+appVersion: "auto"
 description: A Python based monitoring and tracking tool for Plex Media Server
 type: application
 deprecated: false

--- a/charts/traefik/2.0.0/Chart.yaml
+++ b/charts/traefik/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: traefik
 version: 2.0.0
 upstream_version: 9.15.2
-appVersion: 2.4.6
+appVersion: "auto"
 description: A Traefik based Reverse Proxy and Certificate Manager
 type: application
 deprecated: false

--- a/charts/traefik/2.0.0/ix_values.yaml
+++ b/charts/traefik/2.0.0/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   name: traefik
   # defaults to appVersion
-  tag: ""
+  tag: v2.4.6
   pullPolicy: IfNotPresent
 
 #

--- a/charts/traefik/2.0.0/test_values.yaml
+++ b/charts/traefik/2.0.0/test_values.yaml
@@ -2,7 +2,7 @@
 image:
   name: traefik
   # defaults to appVersion
-  tag: ""
+  tag: v2.4.6
   pullPolicy: IfNotPresent
 
 #

--- a/charts/transmission/2.0.0/Chart.yaml
+++ b/charts/transmission/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: transmission
 version: 2.0.0
 # upstream_version:
-appVersion: "version-v0.17.153"
+appVersion: "auto"
 description: API Support for your favorite torrent trackers.
 type: application
 deprecated: false

--- a/charts/truecommand/2.0.0/Chart.yaml
+++ b/charts/truecommand/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: truecommand
 version: 2.0.0
 # upstream_version: 1.1.0
-appVersion: 1.3.2
+appVersion: "auto"
 description: Aggregated management of TrueNAS devices
 type: application
 deprecated: false

--- a/charts/unifi/2.0.0/Chart.yaml
+++ b/charts/unifi/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: unifi
 version: 2.0.0
 upstream_version: 1.5.1
-appVersion: 5.14.23
+appVersion: "auto"
 description: Ubiquiti Network's Unifi Controller
 type: application
 deprecated: false

--- a/charts/unifi/2.0.0/ix_values.yaml
+++ b/charts/unifi/2.0.0/ix_values.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: jacobalberty/unifi
-  tag: stable-6
+  tag: 6.0.45
   pullPolicy: IfNotPresent
 
 ##

--- a/charts/unifi/2.0.0/test_values.yaml
+++ b/charts/unifi/2.0.0/test_values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: jacobalberty/unifi
-  tag: stable-6
+  tag: 6.0.45
   pullPolicy: IfNotPresent
 
 strategy:

--- a/charts/zwavejs2mqtt/2.0.0/Chart.yaml
+++ b/charts/zwavejs2mqtt/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: zwavejs2mqtt
 version: 2.0.0
 upstream_version: 1.1.0
-appVersion: 1.1.1
+appVersion: "auto"
 description: Fully configurable Zwave to MQTT gateway and Control Panel using NodeJS and Vue
 type: application
 deprecated: false

--- a/charts/zwavejs2mqtt/2.0.0/ix_values.yaml
+++ b/charts/zwavejs2mqtt/2.0.0/ix_values.yaml
@@ -8,6 +8,7 @@ image:
   repository: zwavejs/zwavejs2mqtt
   pullPolicy: IfNotPresent
   tag: 1.1.1
+
 probes:
   liveness:
     enabled: true

--- a/library/common-test/values.yaml
+++ b/library/common-test/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: b4bz/homer
-  tag: latest
+  tag: 21.03.1
   pullPolicy: IfNotPresent
 
 services:

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: common
 version: 2.0.0
-# upstream_version: 3.0.1
+# upstream_version:
 # appVersion:
 description: Function library for TrueCharts
 type: library


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

This PR adds an auto-updated bot to the CI stack.
- It automatically updates the tags/versions for the containers used in most Apps.
- It moves some Apps from using latest to using actual versions
- It also goes over some Apps using weird versioning and uses latest in those cases.

This leads to a situation where there are just two versioning systems:
A. "auto" (creating auto-update PR's for the maintainers, to keep versioning in check for the end user)
B. "latest" in cases we can not use reasonable versioning we use latest

Fixes #224

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

The updater is tested manually.
Some proof updating is going to work:
https://github.com/truecharts/charts/pull/244

**Notes:**
<!-- Please enter any other relevant information here -->

Why use "auto" and not the actual tag?
The UI gets all wonky with long tags and tags do **not** equal versions.

**Checklist:**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests to this description that prove my fix is effective or that my feature works
