### PR TITLE
Move Ombi and Readarr to TrueCharts container

### DIFF
--- a/charts/ombi/2.0.0/ix_values.yaml
+++ b/charts/ombi/2.0.0/ix_values.yaml
@@ -5,11 +5,9 @@
 ##
 
 image:
-  repository: linuxserver/ombi
+  repository: ghcr.io/truecharts/ombi
   pullPolicy: IfNotPresent
-  tag: version-v4.0.681
-
-startAsRoot: true
+  tag: v4.0.1222
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/ombi/2.0.0/test_values.yaml
+++ b/charts/ombi/2.0.0/test_values.yaml
@@ -2,14 +2,12 @@
 # Default values for Ombi.
 
 image:
-  repository: linuxserver/ombi
+  repository: ghcr.io/truecharts/ombi
   pullPolicy: IfNotPresent
-  tag: version-v4.0.681
+  tag: v4.0.1222
 
 strategy:
   type: Recreate
-
-startAsRoot: true
 
 services:
   main:

--- a/charts/readarr/2.0.0/Chart.yaml
+++ b/charts/readarr/2.0.0/Chart.yaml
@@ -3,7 +3,7 @@ kubeVersion: ">=1.16.0-0"
 name: readarr
 version: 2.0.0
 upstream_version: 2.1.0
-appVersion: "nightly"
+appVersion: "auto"
 description: A fork of Radarr to work with Books & AudioBooks
 type: application
 deprecated: false

--- a/charts/readarr/2.0.0/ix_values.yaml
+++ b/charts/readarr/2.0.0/ix_values.yaml
@@ -5,11 +5,9 @@
 ##
 
 image:
-  repository: hotio/readarr
+  repository: ghcr.io/truecharts/readarr
   pullPolicy: IfNotPresent
-  tag: nightly
-
-startAsRoot: true
+  tag: v0.1.0.535
 
 probes:
     liveness:

--- a/charts/readarr/2.0.0/test_values.yaml
+++ b/charts/readarr/2.0.0/test_values.yaml
@@ -1,14 +1,12 @@
 # Default values for Radarr.
 
 image:
-  repository: hotio/readarr
+  repository: ghcr.io/truecharts/readarr
   pullPolicy: IfNotPresent
-  tag: nightly
+  tag: v0.1.0.535
 
 strategy:
   type: Recreate
-
-startAsRoot: true
 
 services:
   main:


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR moves Ombi and Readarr to our own containers, which don't use s6_overlay

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests to this description that prove my fix is effective or that my feature works
