### PR TITLE
Add url option to portal configmap

### DIFF
--- a/.tools/tests/charts/common-test_spec.rb
+++ b/.tools/tests/charts/common-test_spec.rb
@@ -323,6 +323,7 @@ class Test < ChartTest
       defaultProtocol = "https"
       defaultHost = "$node_ip"
       defaultPort = "443"
+      defaulturl = "https://$node_ip:443"
       testNodePort = "666"
       testIngressPort = "888"
       it 'No portal (=configmap) is created by default' do
@@ -340,6 +341,7 @@ class Test < ChartTest
         jq('.data.protocol', resource('ConfigMap')).must_equal defaultProtocol
         jq('.data.host', resource('ConfigMap')).must_equal defaultHost
         jq('.data.port', resource('ConfigMap')).must_equal defaultPort
+        jq('.data.url', resource('ConfigMap')).must_equal defaulturl
       end
 
       it 'portal port can be based on NodePort' do

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: common
-version: 2.0.2
+version: 2.0.3
 # upstream_version:
 appVersion: none
 description: Function library for TrueCharts

--- a/library/common/templates/lib/resources/_portal_config.tpl
+++ b/library/common/templates/lib/resources/_portal_config.tpl
@@ -57,6 +57,7 @@ data:
   protocol: {{ $protocol }}
   host: {{ $host }}
   port: {{ $port | quote }}
+  url: {{ printf "%v%v%v%v%v" $protocol "://" $host ":" $port }}
 
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**Description**
It makes it easier to consume the portal url in other places, without all sorts of translation scripting

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
