### PR TITLE
Don't create volume mounts for unmountable PVC's

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: common
-version: 2.2.0
+version: 2.2.1
 # upstream_version:
 appVersion: none
 description: Function library for TrueCharts

--- a/library/common/templates/lib/controller/_container.tpl
+++ b/library/common/templates/lib/controller/_container.tpl
@@ -76,7 +76,7 @@ The main container included in the controller.
   {{- include "common.controller.ports" . | trim | nindent 2 }}
   volumeMounts:
   {{- range $index, $PVC := .Values.persistence }}
-  {{- if $PVC.enabled }}
+  {{- if and ( $PVC.enabled ) ( $PVC.mountPath ) }}
   - mountPath: {{ $PVC.mountPath }}
     name: {{ $index }}
   {{- if $PVC.subPath }}


### PR DESCRIPTION
**Description**
This is a super simple bugfix, that allows us to create PVC's that are not being mounted into the main container. For example: For backup scripts, addon containers and databases