### PR TITLE
Make host and container devicePath the same.

### DIFF
--- a/.tools/tests/charts/common-test_spec.rb
+++ b/.tools/tests/charts/common-test_spec.rb
@@ -251,21 +251,20 @@ class Test < ChartTest
 	describe 'deviceMounts' do
       default_name_1 = 'devicemount-test1'
 	  default_name_2 = 'devicemount-test2'
-      default_mountPath_1 = '/test1'
-	  default_mountPath_2 = '/test2'
+      default_devicePath_1 = '/test1'
+	  default_devicePath_2 = '/test2'
 	  empty_dir = {}
-	  path = '/tmp'
 
       it 'deviceMounts creates VolumeMounts' do
         jq('.spec.template.spec.containers[0].volumeMounts[0].name', resource('Deployment')).must_equal default_name_1
 		jq('.spec.template.spec.containers[0].volumeMounts[1].name', resource('Deployment')).must_equal default_name_2
-		jq('.spec.template.spec.containers[0].volumeMounts[0].mountPath', resource('Deployment')).must_equal default_mountPath_1
-		jq('.spec.template.spec.containers[0].volumeMounts[1].mountPath', resource('Deployment')).must_equal default_mountPath_2
+		jq('.spec.template.spec.containers[0].volumeMounts[0].mountPath', resource('Deployment')).must_equal default_devicePath_1
+		jq('.spec.template.spec.containers[0].volumeMounts[1].mountPath', resource('Deployment')).must_equal default_devicePath_2
       end
 
       it 'deviceMounts creates Volumes' do
 		jq('.spec.template.spec.volumes[0].emptyDir', resource('Deployment')).must_equal empty_dir
-		jq('.spec.template.spec.volumes[1].hostPath.path', resource('Deployment')).must_equal path
+		jq('.spec.template.spec.volumes[1].hostPath.path', resource('Deployment')).must_equal default_devicePath_2
       end
     end
 

--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: common-test
-version: 2.1.2
+version: 2.1.3
 # upstream_version:
 appVersion: none
 description: Helper chart to test different use cases of the common library

--- a/library/common-test/ci/default-values.yaml
+++ b/library/common-test/ci/default-values.yaml
@@ -66,20 +66,6 @@ persistence:
     storageClass: ""
 
 # these values and names are set specifically with the unittests in mind.
-fixMountPermissions: false
-deviceMounts:
-  test1:
-    enabled: true
-    emptyDir: true
-    mountPath: "/test1"
-    hostPath: "/tmp"
-  test2:
-    enabled: true
-    emptyDir: false
-    mountPath: "/test2"
-    hostPath: "/tmp"
-
-# these values and names are set specifically with the unittests in mind.
 customStorage:
   - name: "test3"
     enabled: true
@@ -92,3 +78,14 @@ customStorage:
     setPermissions: true
     mountPath: "/test4"
     hostPath: "/tmp"
+
+deviceMounts:
+  test1:
+    enabled: true
+    emptyDir: true
+    devicePath: "/test1"
+  test2:
+    enabled: true
+    emptyDir: false
+    devicePath: "/test2"
+

--- a/library/common-test/values.yaml
+++ b/library/common-test/values.yaml
@@ -60,13 +60,11 @@ deviceMounts:
   test1:
     enabled: true
     emptyDir: true
-    mountPath: "/test1"
-    hostPath: "/tmp"
+    devicePath: "/test1"
   test2:
     enabled: true
     emptyDir: false
-    mountPath: "/test2"
-    hostPath: "/tmp"
+    devicePath: "/test2"
 
 # these values and names are set specifically with the unittests in mind.
 customStorage:

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: common
-version: 3.0.3
+version: 3.0.4
 # upstream_version:
 appVersion: none
 description: Function library for TrueCharts

--- a/library/common/templates/lib/controller/_volumeMounts.tpl
+++ b/library/common/templates/lib/controller/_volumeMounts.tpl
@@ -20,7 +20,7 @@ Volumes included by the controller.
   {{ $name = $dmm.name }}
 {{ end }}
 - name: devicemount-{{ $name }}
-  mountPath: {{ $dmm.mountPath }}
+  mountPath: {{ $dmm.devicePath }}
   {{ if $dmm.subPath }}
   subPath: {{ $dmm.subPath }}
   {{ end }}

--- a/library/common/templates/lib/controller/_volumes.tpl
+++ b/library/common/templates/lib/controller/_volumes.tpl
@@ -57,7 +57,7 @@ Volumes included by the controller.
   emptyDir: {}
   {{- else -}}
   hostPath:
-    path: {{ required "hostPath not set" $dm.hostPath }}
+    path: {{ required "hostPath not set" $dm.devicePath }}
   {{ end }}
 {{ end }}
 {{- end -}}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -296,24 +296,18 @@ PGID: 568
 UMASK: "002"
 fixMountPermissions: true
 
-# appVolumeMounts:
+# deviceMounts:
 #   config:
 #     enabled: false
 #     emptyDir: false
-#     datasetName: "config"
-#     mountPath: "/config"
-#     subPath: some-subpath
-#     hostPathEnabled: false
-#     hostPath: ""
+#     hostPath: "/config"
 #     setPermissions: true
 
-# additionalAppVolumeMounts:
+# customStorage:
 #   - name: "data"
 #     enabled: false
 #     emptyDir: false
-#     datasetName: "data"
 #     mountPath: "/data"
 #     subPath: some-subpath
-#     hostPathEnabled: false
 #     hostPath: ""
 #     setPermissions: true


### PR DESCRIPTION
**Description**
This PR makes mounted USB devices always be the same on both Host and Container, to prevent any issues along the way.

It also leads to a cleaner and more streamlined UX for the install GUI.

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
