### PR TITLE
allow setting readOnly on customStorage and limit permissionsmounts

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: common-test
-version: 2.1.3
+version: 2.1.4
 # upstream_version:
 appVersion: none
 description: Helper chart to test different use cases of the common library

--- a/library/common-test/values.yaml
+++ b/library/common-test/values.yaml
@@ -55,7 +55,6 @@ additionalIngress:
     enabled: true
 
 # these values and names are set specifically with the unittests in mind.
-fixMountPermissions: false
 deviceMounts:
   test1:
     enabled: true

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: common
-version: 3.0.4
+version: 3.5.0
 # upstream_version:
 appVersion: none
 description: Function library for TrueCharts

--- a/library/common/templates/lib/controller/_volumeMounts.tpl
+++ b/library/common/templates/lib/controller/_volumeMounts.tpl
@@ -37,6 +37,9 @@ Volumes included by the controller.
   {{ if $csm.subPath }}
   subPath: {{ $csm.subPath }}
   {{ end }}
+  {{ if $csm.readOnly
+  readOnly: {{ $csm.readOnly }}
+  {{ end }}
 {{- end -}}
 {{ end }}
 

--- a/library/common/templates/lib/controller/_volumeMounts.tpl
+++ b/library/common/templates/lib/controller/_volumeMounts.tpl
@@ -37,7 +37,7 @@ Volumes included by the controller.
   {{ if $csm.subPath }}
   subPath: {{ $csm.subPath }}
   {{ end }}
-  {{ if $csm.readOnly
+  {{ if $csm.readOnly }}
   readOnly: {{ $csm.readOnly }}
   {{ end }}
 {{- end -}}

--- a/library/common/templates/lib/storage/_mountPermissions.tpl
+++ b/library/common/templates/lib/storage/_mountPermissions.tpl
@@ -40,11 +40,40 @@ spec:
           #securityContext:
           #
           volumeMounts:
-            {{- include "common.controller.volumeMounts" . | indent 12 }}
-      {{- with (include "common.controller.volumes" . | trim) }}
+          {{ range $name, $csm := .Values.customStorage }}
+          {{- if $csm.enabled -}}
+          {{- if $csm.setPermissions -}}
+          {{ if $csm.name }}
+            {{ $name = $csm.name }}
+          {{ end }}
+          - name: customstorage-{{ $name }}
+            mountPath: {{ $csm.mountPath }}
+            {{ if $csm.subPath }}
+            subPath: {{ $csm.subPath }}
+            {{ end }}
+            {{ if $csm.readOnly }}
+            readOnly: {{ $csm.readOnly }}
+            {{ end }}
+          {{- end -}}
+          {{- end -}}
+          {{ end }}
       volumes:
-        {{- . | nindent 8 }}
-      {{- end }}
+      {{- range $name, $cs := .Values.customStorage -}}
+      {{ if $cs.enabled }}
+      {{ if $cs.setPermissions }}
+      {{ if $cs.name }}
+      {{ $name = $cs.name }}
+      {{ end }}
+      - name: customstorage-{{ $name }}
+        {{ if $cs.emptyDir }}
+        emptyDir: {}
+        {{- else -}}
+        hostPath:
+          path: {{ required "hostPath not set" $cs.hostPath }}
+        {{ end }}
+      {{ end }}
+      {{ end }}
+      {{- end -}}
 
 
 {{- end }}

--- a/library/common/values.yaml
+++ b/library/common/values.yaml
@@ -310,4 +310,5 @@ fixMountPermissions: true
 #     mountPath: "/data"
 #     subPath: some-subpath
 #     hostPath: ""
+#     readOnly: false
 #     setPermissions: true


### PR DESCRIPTION
**Description**
This PR adds the option to set readOnly volumeMounting for custom Storage options.

It's a super clean feature, but has not been added to the individual App UI's with this patch.

It also limits the amount of volumes mounted to the automated permissions fix job.

Fixes #271

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
