### PR TITLE
Remove duplicate forward auth url in questions yaml

### DIFF
--- a/stable/radarr/3.1.2/questions.yaml
+++ b/stable/radarr/3.1.2/questions.yaml
@@ -362,12 +362,6 @@ questions:
                   show_if: [["certType", "!=", "disabled"]]
                   type: string
                   default: ""
-              - variable: authForwardURL
-                label: "Forward Authentication URL"
-                schema:
-                  type: string
-                  default: ""
-
   - variable: UMASK
     group: "Advanced"
     label: "UMASK"


### PR DESCRIPTION
**Description**
This removed a duplicate question that is shown in the SCALE UI when creating a radarr app. The duplicate entries are shown below:

<img width="768" alt="Screen Shot 2021-04-24 at 4 25 29 PM" src="https://user-images.githubusercontent.com/867868/115971971-c0106f00-a519-11eb-9484-e955783518e9.png">



**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
I'm not sure how to test this without spinning up an entire TrueNAS SCALE box just for testing.

**Checklist:**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
