### PR TITLE
Refactor nodePorts so all apps have unique defaults

### DIFF
--- a/docs/manual/default-nodePorts.md
+++ b/docs/manual/default-nodePorts.md
@@ -2,8 +2,7 @@
 
 | App                       |Service  | NodePort  |
 |:--------------------------|:-------:|:---------:|
-|Bitwarden                  |Main     |36000      |
-|Bitwarden                  |Websocket|36001      |
+|Plex                       |Main     |32400      |
 |Handbrake                  |Main     |36002      |
 |Handbrake                  |VNC      |36003      |
 |Collabora                  |Main     |36004      |
@@ -17,20 +16,23 @@
 |Lidarr                     |Main     |36012      |
 |Ombi                       |Main     |36013      |
 |Lidarr                     |Main     |36014      |
-|Plex                       |Main     |36015      | <!--- Should we leave 32400 default ? -->
+|Calibre-Web                |Main     |36015      |
 |Radarr                     |Main     |36016      |
 |Sonarr                     |Main     |36017      |
 |Tautulli                   |Main     |36018      |
 |Transmission               |Main     |36019      |
 |Transmission               |TCP      |36020      |
-|Transmission               |UDP      |36021      |
+|Transmission               |UDP      |36020      |
+|NZBGet                     |Main     |36021      |
 |ZwaveJS2Mqtt               |Main     |36022      |
 |ZwaveJS2Mqtt               |Websocket|36023      |
-|Syncthing                  |Main     |36024      | <!--- NodePort seems commented out? -->
+|Syncthing                  |Main     |36024      |
 |Bazarr                     |Main     |36025      |
 |Deluge                     |Main     |36026      |
-|Deluge                     |TCP      |36027      | <!--- Shoule we leave 51413 default ? -->
-|Deluge                     |UDP      |36028      | <!--- Shoule we leave 51413 default ? -->
+|Deluge                     |TCP      |51413      |
+|Deluge                     |UPD      |51413      |
+|Navidrome                  |Main     |36027      |
+|Node-RED                   |Main     |36028      |
 |FreshRSS                   |Main     |36029      |
 |GAPS                       |Main     |36030      |
 |Grocy                      |Main     |36031      |
@@ -43,17 +45,17 @@
 |Readarr                    |Main     |36038      |
 |QBitTorrent                |Main     |36039      |
 |QBitTorrent                |TCP      |36040      |
-|QBitTorrent                |UDP      |36041      |
+|QBitTorrent                |UDP      |36040      |
+|NZBHydra                   |Main     |36041      |
 |TVHeadend                  |Main     |36042      |
 |TVHeadend                  |HTSP     |36043      |
 |True Command               |Main     |36044      |
 |SABnzbd                    |Main     |36045      |
 |Organizr                   |Main     |36046      |
-|NZBHydra                   |Main     |36047      |
-|NZBGet                     |Main     |36048      |
-|Node-RED                   |Main     |36049      |
-|Navidrome                  |Main     |36050      |
-|Calibre-Web                |Main     |36051      |
+
+
+
+
 
 
 

--- a/docs/manual/default-nodePorts.md
+++ b/docs/manual/default-nodePorts.md
@@ -1,0 +1,59 @@
+# Default Node Ports
+
+| App                       |Service  | NodePort  |
+|:--------------------------|:-------:|:---------:|
+|Bitwarden                  |Main     |36000      |
+|Bitwarden                  |Websocket|36001      |
+|Handbrake                  |Main     |36002      |
+|Handbrake                  |VNC      |36003      |
+|Collabora                  |Main     |36004      |
+|Deepstack                  |Main     |36005      |
+|Emby                       |Main     |36006      |
+|ESPHome                    |Main     |36007      |
+|Home Assistant             |Main     |36008      |
+|Jackett                    |Main     |36009      |
+|Jellyfin                   |Main     |36010      |
+|KMS                        |Main     |36011      |
+|Lidarr                     |Main     |36012      |
+|Ombi                       |Main     |36013      |
+|Lidarr                     |Main     |36014      |
+|Plex                       |Main     |36015      | <!--- Should we leave 32400 default ? -->
+|Radarr                     |Main     |36016      |
+|Sonarr                     |Main     |36017      |
+|Tautulli                   |Main     |36018      |
+|Transmission               |Main     |36019      |
+|Transmission               |TCP      |36020      |
+|Transmission               |UDP      |36021      |
+|ZwaveJS2Mqtt               |Main     |36022      |
+|ZwaveJS2Mqtt               |Websocket|36023      |
+|Syncthing                  |Main     |36024      | <!--- NodePort seems commented out? -->
+|Bazarr                     |Main     |36025      |
+|Deluge                     |Main     |36026      |
+|Deluge                     |TCP      |36027      | <!--- Shoule we leave 51413 default ? -->
+|Deluge                     |UDP      |36028      | <!--- Shoule we leave 51413 default ? -->
+|FreshRSS                   |Main     |36029      |
+|GAPS                       |Main     |36030      |
+|Grocy                      |Main     |36031      |
+|Heimdall                   |Main     |36032      |
+|Lazy Librarian             |Main     |36033      |
+|Lychee                     |Main     |36034      |
+|Unifi                      |Main     |36035      |
+|Unifi                      |TCP      |36036      |
+|Unifi                      |UDP      |36037      |
+|Readarr                    |Main     |36038      |
+|QBitTorrent                |Main     |36039      |
+|QBitTorrent                |TCP      |36040      |
+|QBitTorrent                |UDP      |36041      |
+|TVHeadend                  |Main     |36042      |
+|TVHeadend                  |HTSP     |36043      |
+|True Command               |Main     |36044      |
+|SABnzbd                    |Main     |36045      |
+|Organizr                   |Main     |36046      |
+|NZBHydra                   |Main     |36047      |
+|NZBGet                     |Main     |36048      |
+|Node-RED                   |Main     |36049      |
+|Navidrome                  |Main     |36050      |
+|Calibre-Web                |Main     |36051      |
+
+
+

--- a/docs/manual/default-nodePorts.md
+++ b/docs/manual/default-nodePorts.md
@@ -53,9 +53,4 @@
 |SABnzbd                    |Main     |36045      |
 |Organizr                   |Main     |36046      |
 
-
-
-
-
-
-
+#### Note: TCP and UPD ports that are the same in each App, are not by mistake.

--- a/incubator/bazarr/3.1.2/questions.yaml
+++ b/incubator/bazarr/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36025
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/calibre-web/3.1.2/questions.yaml
+++ b/incubator/calibre-web/3.1.2/questions.yaml
@@ -158,7 +158,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36051
+                        default: 36015
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/calibre-web/3.1.2/questions.yaml
+++ b/incubator/calibre-web/3.1.2/questions.yaml
@@ -158,7 +158,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36051
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/deluge/3.1.2/questions.yaml
+++ b/incubator/deluge/3.1.2/questions.yaml
@@ -331,7 +331,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36027
+                        default: 51413
                         required: false
         - variable: udp
           label: ""
@@ -392,7 +392,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36028
+                        default: 51413
                         required: false
 
 ## Ingres

--- a/incubator/deluge/3.1.2/questions.yaml
+++ b/incubator/deluge/3.1.2/questions.yaml
@@ -270,7 +270,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36026
                         required: true
         - variable: tcp
           label: ""
@@ -331,7 +331,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 51413
+                        default: 36027
                         required: false
         - variable: udp
           label: ""
@@ -392,7 +392,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 51413
+                        default: 36028
                         required: false
 
 ## Ingres

--- a/incubator/freshrss/3.1.2/questions.yaml
+++ b/incubator/freshrss/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36029
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/gaps/3.1.2/questions.yaml
+++ b/incubator/gaps/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36030
                         required: true
   - variable: persistence
     label: "Integrated Persistent Storage"

--- a/incubator/grocy/3.1.2/questions.yaml
+++ b/incubator/grocy/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36031
                         required: true
   - variable: persistence
     label: "Integrated Persistent Storage"

--- a/incubator/heimdall/3.1.2/questions.yaml
+++ b/incubator/heimdall/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36033
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/lazylibrarian/3.1.2/questions.yaml
+++ b/incubator/lazylibrarian/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36033
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/lychee/3.1.2/questions.yaml
+++ b/incubator/lychee/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36034
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/navidrome/3.1.2/Chart.yaml
+++ b/incubator/navidrome/3.1.2/Chart.yaml
@@ -8,7 +8,7 @@ description: Navidrome is an open source web-based music collection server and s
 type: application
 deprecated: false
 home: https://github.com/truecharts/apps/tree/master/incubator/navidrome
-icon: https://github.com/deluan/navidrome/blob/master/ui/src/icons/android-icon-72x72.png?raw=true
+icon: https://raw.githubusercontent.com/navidrome/navidrome/v0.42.0/ui/src/icons/android-icon-192x192.png
 keywords:
   - navidrome
   - music

--- a/incubator/navidrome/3.1.2/questions.yaml
+++ b/incubator/navidrome/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36050
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/navidrome/3.1.2/questions.yaml
+++ b/incubator/navidrome/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36050
+                        default: 36027
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/navidrome/item.yaml
+++ b/incubator/navidrome/item.yaml
@@ -1,3 +1,3 @@
 categories:
   - media
-icon_url: https://github.com/deluan/navidrome/blob/master/ui/src/icons/android-icon-72x72.png?raw=true
+icon_url: https://raw.githubusercontent.com/navidrome/navidrome/v0.42.0/ui/src/icons/android-icon-192x192.png

--- a/incubator/node-red/3.1.2/questions.yaml
+++ b/incubator/node-red/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36049
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/node-red/3.1.2/questions.yaml
+++ b/incubator/node-red/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36049
+                        default: 36028
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/nzbget/3.1.2/questions.yaml
+++ b/incubator/nzbget/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36048
+                        default: 36021
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/nzbget/3.1.2/questions.yaml
+++ b/incubator/nzbget/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36048
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/nzbhydra/3.1.2/questions.yaml
+++ b/incubator/nzbhydra/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36047
+                        default: 36041
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/nzbhydra/3.1.2/questions.yaml
+++ b/incubator/nzbhydra/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36047
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/organizr/3.1.2/questions.yaml
+++ b/incubator/organizr/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36046
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/qbittorrent/3.1.2/questions.yaml
+++ b/incubator/qbittorrent/3.1.2/questions.yaml
@@ -285,7 +285,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36041
+                        default: 36040
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/qbittorrent/3.1.2/questions.yaml
+++ b/incubator/qbittorrent/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36039
                         required: true
         - variable: tcp
           label: "TCP Torrent connections"
@@ -222,7 +222,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36040
                         required: true
         - variable: udp
           label: "UDP Torrent connections"
@@ -285,7 +285,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36041
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/readarr/3.1.2/questions.yaml
+++ b/incubator/readarr/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36038
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/sabnzbd/3.1.2/questions.yaml
+++ b/incubator/sabnzbd/3.1.2/questions.yaml
@@ -175,7 +175,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36045
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/truecommand/3.1.2/questions.yaml
+++ b/incubator/truecommand/3.1.2/questions.yaml
@@ -160,7 +160,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36044
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/incubator/tvheadend/4.1.2/questions.yaml
+++ b/incubator/tvheadend/4.1.2/questions.yaml
@@ -140,7 +140,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36042
                         required: true
         - variable: htsp
           label: "HTSP service"
@@ -202,7 +202,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36043
                         required: true
   - variable: persistence
     label: "Integrated Persistent Storage"

--- a/incubator/unifi/3.1.2/questions.yaml
+++ b/incubator/unifi/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36035
                         required: true
         - variable: tcp
           label: "Unifi Device Communications"
@@ -222,7 +222,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36036
                         required: true
         - variable: udp
           label: "Stun Device Communications"
@@ -285,7 +285,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36037
                         required: true
   - variable: persistence
     label: "Integrated Persistent Storage"

--- a/stable/bitwarden/1.1.3/questions.yaml
+++ b/stable/bitwarden/1.1.3/questions.yaml
@@ -455,7 +455,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36000
                         required: true
                         hidden: true
         - variable: ws
@@ -517,7 +517,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36053
+                        default: 36001
                         required: true
                         hidden: true
 

--- a/stable/collabora-online/3.1.2/questions.yaml
+++ b/stable/collabora-online/3.1.2/questions.yaml
@@ -207,7 +207,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36004
                         required: true
   # Reverse Proxy
   - variable: customStorage

--- a/stable/deepstack-cpu/1.0.0/questions.yaml
+++ b/stable/deepstack-cpu/1.0.0/questions.yaml
@@ -224,7 +224,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36005
                         required: true
 
 ## TrueCharts Specific

--- a/stable/deepstack-cpu/1.0.0/test_values.yaml
+++ b/stable/deepstack-cpu/1.0.0/test_values.yaml
@@ -27,11 +27,11 @@ envTpl:
 
 env:
   # TZ: UTC
-  VISION-FACE: True
-  VISION-DETECTION: True
-  VISION-SCENE: True
+  VISION-FACE: "True"
+  VISION-DETECTION: "True"
+  VISION-SCENE: "True"
   MODELSTORE-DETECTION: "/modelstore/detection"    # Path to custom models (needs to be on documentation)
-  MODE: High        # High|Medium|Low
+  MODE: "High"        # High|Medium|Low
   # ADMIN-KEY: "" # Deprecated since it got OpenSource? or optional?
   # API-KEY: "" # Deprecated since it got OpenSource? or optional?podSecurityContext:
 

--- a/stable/emby/3.1.2/questions.yaml
+++ b/stable/emby/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36006
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/esphome/3.1.2/questions.yaml
+++ b/stable/esphome/3.1.2/questions.yaml
@@ -158,7 +158,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36007
                         required: true
   # Configure app volumes
   - variable: persistence

--- a/stable/handbrake/3.1.2/questions.yaml
+++ b/stable/handbrake/3.1.2/questions.yaml
@@ -244,7 +244,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36002
                         required: true
         - variable: vnc
           label: "VNC service"
@@ -307,7 +307,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36003
                         required: true
 
 ## TrueCharts Specific

--- a/stable/home-assistant/3.1.2/questions.yaml
+++ b/stable/home-assistant/3.1.2/questions.yaml
@@ -174,7 +174,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36008
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/jackett/3.1.2/questions.yaml
+++ b/stable/jackett/3.1.2/questions.yaml
@@ -158,7 +158,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36009
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/jellyfin/3.1.2/questions.yaml
+++ b/stable/jellyfin/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36010
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/kms/3.1.2/questions.yaml
+++ b/stable/kms/3.1.2/questions.yaml
@@ -151,7 +151,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36011
                         required: true
 ## TrueCharts Specific
   - variable: customStorage

--- a/stable/lidarr/3.1.2/questions.yaml
+++ b/stable/lidarr/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36012
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/ombi/3.1.2/questions.yaml
+++ b/stable/ombi/3.1.2/questions.yaml
@@ -159,7 +159,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36013
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/plex/2.1.2/questions.yaml
+++ b/stable/plex/2.1.2/questions.yaml
@@ -183,7 +183,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36015
+                        default: 32400
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/plex/2.1.2/questions.yaml
+++ b/stable/plex/2.1.2/questions.yaml
@@ -183,7 +183,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 32400
+                        default: 36015
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/radarr/3.1.2/questions.yaml
+++ b/stable/radarr/3.1.2/questions.yaml
@@ -160,7 +160,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36016
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/sonarr/3.1.2/questions.yaml
+++ b/stable/sonarr/3.1.2/questions.yaml
@@ -160,7 +160,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36017
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/syncthing/3.1.2/questions.yaml
+++ b/stable/syncthing/3.1.2/questions.yaml
@@ -150,7 +150,7 @@ questions:
                     #     type: int
                     #     min: 9000
                     #     max: 65535
-                    #     default: 36052
+                    #     default: 36024
                     #     required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/tautulli/3.1.2/questions.yaml
+++ b/stable/tautulli/3.1.2/questions.yaml
@@ -160,7 +160,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36018
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/transmission/3.1.2/questions.yaml
+++ b/stable/transmission/3.1.2/questions.yaml
@@ -468,7 +468,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36021
+                        default: 36020
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/transmission/3.1.2/questions.yaml
+++ b/stable/transmission/3.1.2/questions.yaml
@@ -342,7 +342,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36019
                         required: true
         - variable: tcp
           label: "TCP Torrent connections"
@@ -405,7 +405,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36020
                         required: true
         - variable: udp
           label: "UDP Torrent connections"
@@ -468,7 +468,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36021
                         required: true
 ## TrueCharts Specific
   - variable: persistence

--- a/stable/zwavejs2mqtt/3.1.2/questions.yaml
+++ b/stable/zwavejs2mqtt/3.1.2/questions.yaml
@@ -139,7 +139,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36022
                         required: true
         - variable: ws
           label: "WebSocket service"
@@ -202,7 +202,7 @@ questions:
                         type: int
                         min: 9000
                         max: 65535
-                        default: 36052
+                        default: 36023
                         required: true
   # Configure app volumes
   - variable: persistence


### PR DESCRIPTION
**Description**
This PR changes default nodePorts on all apps, to make them unique. 
Installing apps with defaults now won't cause port conflicts

This will help new people installing our charts to have smoother experience.
Fixes #406 (first part)

**Type of change**

- [ ] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
If you think the table model should change, or port numbers on certain apps should left untouched, 
Please let me know.

Also fixes the icon on Navidrome, the old one was 404.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
