### PR TITLE
Add Syncthing listening ports

### DIFF
--- a/stable/syncthing/SCALE/questions.yaml
+++ b/stable/syncthing/SCALE/questions.yaml
@@ -141,8 +141,8 @@ questions:
                       schema:
                         type: int
                         default: 8384
-                        editable: true
-                        hidden: false
+                        editable: false
+                        hidden: true
                     - variable: nodePort
                       label: "Host nodePort to expose to (optional)"
                       description: "Only gets used when nodePort is selected"

--- a/stable/syncthing/SCALE/questions.yaml
+++ b/stable/syncthing/SCALE/questions.yaml
@@ -141,17 +141,120 @@ questions:
                       schema:
                         type: int
                         default: 8384
-                        editable: false
+                        editable: true
+                        hidden: false
+                    - variable: nodePort
+                      label: "Host nodePort to expose to (optional)"
+                      description: "Only gets used when nodePort is selected"
+                      schema:
+                        type: int
+                        min: 9000
+                        max: 65535
+                        default: 36024
+                        required: true
+        - variable: listeners
+          label: "Syncthing listening ports"
+          description: "This service is used to process incoming connections directly to this Syncthing instance"
+          schema:
+            type: dict
+            attrs:
+              - variable: enabled
+                label: "Enable the service"
+                schema:
+                  type: boolean
+                  default: true
+                  hidden: false
+              - variable: type
+                label: "Service type"
+                description: "ClusterIP's are only internally available, nodePorts expose the container to the host node System"
+                schema:
+                  type: string
+                  default: "NodePort"
+                  enum:
+                    - value: "NodePort"
+                      description: "NodePort"
+                    - value: "ClusterIP"
+                      description: "ClusterIP"
+              - variable: port
+                label: "TCP port"
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: protocol
+                      label: "Port Type"
+                      schema:
+                        type: string
+                        default: "UDP"
                         hidden: true
-                    # - variable: nodePort
-                    #   label: "Host nodePort to expose to (optional)"
-                    #   description: "Only gets used when nodePort is selected"
-                    #   schema:
-                    #     type: int
-                    #     min: 9000
-                    #     max: 65535
-                    #     default: 36024
-                    #     required: true
+                        enum:
+                          - value: TCP
+                            description: "TCP"
+                          - value: "UDP"
+                            description: "UDP"
+                    - variable: port
+                      label: "Container port"
+                      schema:
+                        type: int
+                        default: 22000
+                        editable: true
+                        hidden: false
+                    - variable: targetport
+                      label: "Internal Service port"
+                      description: "When connecting internally to this App, you'll need this port"
+                      schema:
+                        type: int
+                        default: 22000
+                        editable: true
+                        hidden: false
+                    - variable: nodePort
+                      label: "(optional) host nodePort to expose to"
+                      description: "only get used when nodePort is selected"
+                      schema:
+                        type: int
+                        min: 9000
+                        max: 65535
+                        default: 22000
+                        required: true
+              - variable: port
+                label: "UDP port"
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: protocol
+                      label: "Port Type"
+                      schema:
+                        type: string
+                        default: "TCP"
+                        hidden: true
+                        enum:
+                          - value: TCP
+                            description: "TCP"
+                          - value: "UDP"
+                            description: "UDP"
+                    - variable: port
+                      label: "Container port"
+                      schema:
+                        type: int
+                        default: 22000
+                        editable: true
+                        hidden: false
+                    - variable: targetport
+                      label: "Internal Service port"
+                      description: "When connecting internally to this App, you'll need this port"
+                      schema:
+                        type: int
+                        default: 22000
+                        editable: true
+                        hidden: false
+                    - variable: nodePort
+                      label: "(optional) host nodePort to expose to"
+                      description: "only get used when nodePort is selected"
+                      schema:
+                        type: int
+                        min: 9000
+                        max: 65535
+                        default: 22000
+                        required: true                        
 ## TrueCharts Specific
   - variable: persistence
     label: "Integrated Persistent Storage"

--- a/stable/syncthing/SCALE/questions.yaml
+++ b/stable/syncthing/SCALE/questions.yaml
@@ -175,7 +175,7 @@ questions:
                       description: "NodePort"
                     - value: "ClusterIP"
                       description: "ClusterIP"
-              - variable: port
+              - variable: tcp
                 label: "TCP port"
                 schema:
                   type: dict
@@ -215,7 +215,7 @@ questions:
                         max: 65535
                         default: 22000
                         required: true
-              - variable: port
+              - variable: udp
                 label: "UDP port"
                 schema:
                   type: dict


### PR DESCRIPTION
**Description**
Syncthing uses port 22000 by default to listen for incoming connections from other Syncthing instances. This is only configurable through the Syncthing web-ui. I think it's a good idea to add these ports by default in the questions.yaml.

This PR also adds the main service nodeport that for some reason I commented out when I initially added Syncthing.

**Type of change**
- [x] Feature

**How Has This Been Tested?**
Not yet thoroughly tested, please do not merge.

**Notes:**
Because the ports are configurable in the web-ui, I have set `editable: true`. I used Transmission as an example for the TCP/UDP ports. The main purpose here is to expose the container ports as a nodePort, I'm still pretty new to this so I'm wondering if the `targetport` I copied over from transmission is even necessary in this case.

There are also some other things I came across I found slightly confusing which I will mention as comments on the specific lines I added.

Please do not merge this yet as it's not tested, I already made the PR to gather feedback, ask a few questions and test the pipeline :)

**Checklist:**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
