### PR TITLE
Allow injecting portal in non-common charts

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources:
 type: library
-version: 5.1.3
+version: 5.3.0

--- a/charts/library/common/templates/classes/_portal.tpl
+++ b/charts/library/common/templates/classes/_portal.tpl
@@ -3,29 +3,33 @@
 {{- if .Values.portal }}
 {{- if .Values.portal.enabled }}
 
-{{- if .Values.portal.inject.service }}
-{{- $primaryService := ( tpl .Values.portal.inject.service $ ) }}
-{{- else }}
-{{- $primaryService := get .Values.service (include "common.service.primary" .) }}
-{{- end }}
-
-{{- if .Values.portal.inject.port }}
-{{- $primaryPort := ( tpl .Values.portal.inject.port $ ) -}}
-{{- else }}
-{{- $primaryPort := get $primaryService.ports (include "common.classes.service.ports.primary" (dict "values" $primaryService)) -}}
-{{- end }}
-
-{{- if .Values.portal.inject.ingress }}
-{{- $primaryPort := ( tpl .Values.portal.inject.ingress $ ) -}}
-{{- else }}
-{{- $ingr := index .Values.ingress (keys .Values.ingress | first) -}}
-{{- end }}
 
 {{- $host := "$node_ip" }}
 {{- $port := 443 }}
 {{- $protocol := "https" }}
 {{- $portProtocol := "" }}
 {{- $path := "/" }}
+{{- $primaryService := nil }}
+{{- $primaryPort := nil }}
+{{- $ingr := nil }}
+
+{{- if .Values.portal.inject.service }}
+{{- $primaryService = ( tpl .Values.portal.inject.service $ ) }}
+{{- else }}
+{{- $primaryService = get .Values.service (include "common.service.primary" .) }}
+{{- end }}
+
+{{- if .Values.portal.inject.port }}
+{{- $primaryPort = ( tpl .Values.portal.inject.port $ ) -}}
+{{- else }}
+{{- $primaryPort = get $primaryService.ports (include "common.classes.service.ports.primary" (dict "values" $primaryService)) -}}
+{{- end }}
+
+{{- if .Values.portal.inject.ingress }}
+{{- $ingr = ( tpl .Values.portal.inject.ingress $ ) -}}
+{{- else }}
+{{- $ingr = index .Values.ingress (keys .Values.ingress | first) -}}
+{{- end }}
 
 {{- if $ingr }}
   {{- if $ingr.enabled }}

--- a/charts/library/common/templates/classes/_portal.tpl
+++ b/charts/library/common/templates/classes/_portal.tpl
@@ -2,9 +2,25 @@
 
 {{- if .Values.portal }}
 {{- if .Values.portal.enabled }}
+
+{{- if .Values.portal.inject.service }}
+{{- $primaryService := ( tpl .Values.portal.inject.service $ ) }}
+{{- else }}
 {{- $primaryService := get .Values.service (include "common.service.primary" .) }}
+{{- end }}
+
+{{- if .Values.portal.inject.port }}
+{{- $primaryPort := ( tpl .Values.portal.inject.port $ ) -}}
+{{- else }}
 {{- $primaryPort := get $primaryService.ports (include "common.classes.service.ports.primary" (dict "values" $primaryService)) -}}
+{{- end }}
+
+{{- if .Values.portal.inject.ingress }}
+{{- $primaryPort := ( tpl .Values.portal.inject.ingress $ ) -}}
+{{- else }}
 {{- $ingr := index .Values.ingress (keys .Values.ingress | first) -}}
+{{- end }}
+
 {{- $host := "$node_ip" }}
 {{- $port := 443 }}
 {{- $protocol := "https" }}


### PR DESCRIPTION
**Description**
This PR aims to allow the common portal to be used in other charts that follow a totally different service, port and/or ingress structure.

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
