### PR TITLE
introduce dynamic probes for common-chart

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources:
 type: library
-version: 6.2.0
+version: 6.3.0

--- a/charts/library/common/templates/lib/controller/_probes.tpl
+++ b/charts/library/common/templates/lib/controller/_probes.tpl
@@ -19,11 +19,9 @@ Probes selection logic.
         {{- if or ( eq $primaryPort.protocol "HTTP" ) ( eq $primaryPort.protocol "HTTPS" ) -}}
           {{- "httpGet:" | nindent 2 }}
             {{- printf "path: %v" $probe.path | nindent 4 }}
-            {{- ( printf "path: %v" "/" ) | nindent 4 }}
             {{- printf "scheme: %v" $primaryPort.protocol | nindent 4 }}
         {{- else -}}
           {{- "tcpSocket:" | nindent 2 }}
-            {{- printf "port: %v" $primaryPort.port  | nindent 4 }}
         {{- end }}
             {{- printf "port: %v" $primaryPort.port  | nindent 4 }}
         {{- printf "initialDelaySeconds: %v" $probe.spec.initialDelaySeconds  | nindent 2 }}

--- a/charts/library/common/templates/lib/controller/_probes.tpl
+++ b/charts/library/common/templates/lib/controller/_probes.tpl
@@ -16,10 +16,14 @@ Probes selection logic.
       {{- $probe.spec | toYaml | nindent 2 }}
     {{- else }}
       {{- if and $primaryService $primaryPort -}}
-        {{- if or ( eq $primaryPort.protocol "HTTP" ) ( eq $primaryPort.protocol "HTTPS" ) -}}
-          {{- "httpGet:" | nindent 2 }}
-            {{- printf "path: %v" $probe.path | nindent 4 }}
-            {{- printf "scheme: %v" $primaryPort.protocol | nindent 4 }}
+        {{- if $primaryPort.protocol -}}
+          {{- if or ( eq $primaryPort.protocol "HTTP" ) ( eq $primaryPort.protocol "HTTPS" ) -}}
+            {{- "httpGet:" | nindent 2 }}
+              {{- printf "path: %v" $probe.path | nindent 4 }}
+              {{- printf "scheme: %v" $primaryPort.protocol | nindent 4 }}
+          {{- else -}}
+            {{- "tcpSocket:" | nindent 2 }}
+          {{- end }}
         {{- else -}}
           {{- "tcpSocket:" | nindent 2 }}
         {{- end }}

--- a/charts/library/common/templates/lib/controller/_probes.tpl
+++ b/charts/library/common/templates/lib/controller/_probes.tpl
@@ -16,8 +16,16 @@ Probes selection logic.
       {{- $probe.spec | toYaml | nindent 2 }}
     {{- else }}
       {{- if and $primaryService $primaryPort -}}
-        {{- "tcpSocket:" | nindent 2 }}
-          {{- printf "port: %v" $primaryPort.port  | nindent 4 }}
+        {{- if or ( eq $primaryPort.protocol "HTTP" ) ( eq $primaryPort.protocol "HTTPS" ) -}}
+          {{- "httpGet:" | nindent 2 }}
+            {{- printf "path: %v" $probe.path | nindent 4 }}
+            {{- ( printf "path: %v" "/" ) | nindent 4 }}
+            {{- printf "scheme: %v" $primaryPort.protocol | nindent 4 }}
+        {{- else -}}
+          {{- "tcpSocket:" | nindent 2 }}
+            {{- printf "port: %v" $primaryPort.port  | nindent 4 }}
+        {{- end }}
+            {{- printf "port: %v" $primaryPort.port  | nindent 4 }}
         {{- printf "initialDelaySeconds: %v" $probe.spec.initialDelaySeconds  | nindent 2 }}
         {{- printf "failureThreshold: %v" $probe.spec.failureThreshold  | nindent 2 }}
         {{- printf "timeoutSeconds: %v" $probe.spec.timeoutSeconds  | nindent 2 }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -153,6 +153,9 @@ probes:
     enabled: true
     # -- Set this to `true` if you wish to specify your own livenessProbe
     custom: false
+    # -- If a HTTP probe is used (default for HTTP/HTTPS services) this path is used
+    # @default -- "/"
+    path: "/"
     # -- The spec field contains the values for the default livenessProbe.
     # If you selected `custom: true`, this field holds the definition of the livenessProbe.
     # @default -- See below
@@ -169,6 +172,9 @@ probes:
     enabled: true
     # -- Set this to `true` if you wish to specify your own readinessProbe
     custom: false
+    # -- If a HTTP probe is used (default for HTTP/HTTPS services) this path is used
+    # @default -- "/"
+    path: "/"
     # -- The spec field contains the values for the default readinessProbe.
     # If you selected `custom: true`, this field holds the definition of the readinessProbe.
     # @default -- See below
@@ -185,6 +191,9 @@ probes:
     enabled: true
     # -- Set this to `true` if you wish to specify your own startupProbe
     custom: false
+    # -- If a HTTP probe is used (default for HTTP/HTTPS services) this path is used
+    # @default -- "/"
+    path: "/"
     # -- The spec field contains the values for the default startupProbe.
     # If you selected `custom: true`, this field holds the definition of the startupProbe.
     # @default -- See below


### PR DESCRIPTION
**Description**
This is a rather simple patch that adds the ability to set the probe type depending on the primary service, primary port protocol.
(when set to http or https)

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
