### PR TITLE
Fix a bug in storage forceName setting

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources:
 type: library
-version: 6.3.5
+version: 6.3.6

--- a/charts/library/common/templates/lib/controller/_volumes.tpl
+++ b/charts/library/common/templates/lib/controller/_volumes.tpl
@@ -19,6 +19,9 @@ Volumes included by the controller.
       {{- else -}}
         {{- $pvcName = (printf "%s-%s" (include "common.names.fullname" $) $index) -}}
       {{- end -}}
+      {{- if $persistence.forceName -}}
+        {{- $pvcName = $values.forceName -}}
+      {{- end -}}
     {{- end }}
   persistentVolumeClaim:
     claimName: {{ $pvcName }}

--- a/charts/library/common/templates/lib/controller/_volumes.tpl
+++ b/charts/library/common/templates/lib/controller/_volumes.tpl
@@ -20,7 +20,7 @@ Volumes included by the controller.
         {{- $pvcName = (printf "%s-%s" (include "common.names.fullname" $) $index) -}}
       {{- end -}}
       {{- if $persistence.forceName -}}
-        {{- $pvcName = $values.forceName -}}
+        {{- $pvcName = $persistence.forceName -}}
       {{- end -}}
     {{- end }}
   persistentVolumeClaim:


### PR DESCRIPTION
**Description**
The PVC that is mounted when using forceName is wrong. This causes errors with databases and PVC's for example.

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
