### PR TITLE
use TCP probe by default and add docs for probetype

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources:
 type: library
-version: 6.3.7
+version: 6.3.8

--- a/charts/library/common/templates/lib/controller/_probes.tpl
+++ b/charts/library/common/templates/lib/controller/_probes.tpl
@@ -7,7 +7,7 @@ Probes selection logic.
 {{- if $primaryService -}}
   {{- $primaryPort = get $primaryService.ports (include "common.classes.service.ports.primary" (dict "serviceName" (include "common.service.primary" .) "values" $primaryService)) -}}
 {{- end -}}
-{{- $probeType := $probe.type | default "TCP" -}}
+{{- $probeType := "TCP" -}}
 
 {{- range $probeName, $probe := .Values.probes }}
   {{- if $probe.enabled -}}
@@ -20,6 +20,8 @@ Probes selection logic.
           {{- if $probe.type -}}
             {{- if eq $probe.type "AUTO" -}}
               {{- $probeType = $primaryPort.protocol -}}
+            {{- else -}}
+              {{- $probeType := $probe.type -}}
             {{- end }}
           {{- end }}
 

--- a/charts/library/common/templates/lib/controller/_probes.tpl
+++ b/charts/library/common/templates/lib/controller/_probes.tpl
@@ -7,7 +7,7 @@ Probes selection logic.
 {{- if $primaryService -}}
   {{- $primaryPort = get $primaryService.ports (include "common.classes.service.ports.primary" (dict "serviceName" (include "common.service.primary" .) "values" $primaryService)) -}}
 {{- end -}}
-{{- $probeType := "HTTP" -}}
+{{- $probeType := $probe.type | default "TCP" -}}
 
 {{- range $probeName, $probe := .Values.probes }}
   {{- if $probe.enabled -}}
@@ -17,13 +17,11 @@ Probes selection logic.
       {{- $probe.spec | toYaml | nindent 2 }}
     {{- else }}
       {{- if and $primaryService $primaryPort -}}
-        {{- if $probe.type -}}
-          {{- $probeType = $probe.type -}}
-        {{- else -}}
-          {{- if $primaryPort.protocol -}}
-            {{- $probeType = $primaryPort.protocol -}}
+          {{- if $probe.type -}}
+            {{- if eq $probe.type "AUTO" -}}
+              {{- $probeType = $primaryPort.protocol -}}
+            {{- end }}
           {{- end }}
-        {{- end }}
 
           {{- if or ( eq $probeType "HTTPS" ) ( eq $probeType "HTTP" ) -}}
               {{- "httpGet:" | nindent 2 }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -153,6 +153,9 @@ probes:
     enabled: true
     # -- Set this to `true` if you wish to specify your own livenessProbe
     custom: false
+    # -- sets the probe type when not using a custom probe
+    # @default -- "TCP"
+    type: TCP
     # -- If a HTTP probe is used (default for HTTP/HTTPS services) this path is used
     # @default -- "/"
     path: "/"
@@ -172,6 +175,9 @@ probes:
     enabled: true
     # -- Set this to `true` if you wish to specify your own readinessProbe
     custom: false
+    # -- sets the probe type when not using a custom probe
+    # @default -- "TCP"
+    type: TCP
     # -- If a HTTP probe is used (default for HTTP/HTTPS services) this path is used
     # @default -- "/"
     path: "/"
@@ -191,6 +197,9 @@ probes:
     enabled: true
     # -- Set this to `true` if you wish to specify your own startupProbe
     custom: false
+    # -- sets the probe type when not using a custom probe
+    # @default -- "TCP"
+    type: TCP
     # -- If a HTTP probe is used (default for HTTP/HTTPS services) this path is used
     # @default -- "/"
     path: "/"


### PR DESCRIPTION
**Description**
This PR aims to fix all the probe issues, by using a TCP probe by default and adding a "AUTO" probe type for dynamic switching the probe-type based on port.protocol

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
