### PR TITLE
Allow dict being used for statefull set persistence settings

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources:
 type: library
-version: 6.5.4
+version: 6.6.0

--- a/charts/library/common/templates/_statefulset.tpl
+++ b/charts/library/common/templates/_statefulset.tpl
@@ -49,8 +49,12 @@ spec:
       {{- include "common.controller.pod" . | nindent 6 }}
   volumeClaimTemplates:
     {{- range $index, $vct := .Values.volumeClaimTemplates }}
+    {{- $vctname := $index }}
+    {{- if $vct.name }}
+    {{- $vctname := $vct.name }}
+    {{- end }}
     - metadata:
-        name: {{ $vct.name }}
+        name: {{ $vctname }}
       spec:
         accessModes:
           - {{ required (printf "accessMode is required for vCT %v" $vct.name) $vct.accessMode  | quote }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -442,10 +442,12 @@ persistence:
 
 # -- Used in conjunction with `controller.type: statefulset` to create individual disks for each instance.
 volumeClaimTemplates: []
-# - name: data
+# data:
 #   mountPath: /data
 #   accessMode: "ReadWriteOnce"
 #   size: 1Gi
+
+## Or use a list
 # - name: backup
 #   mountPath: /backup
 #   subPath: theSubPath


### PR DESCRIPTION
**Description**
volumeClaimTemplates for statefull sets currently do not allow for dicts being used which makes them borderline unusable for SCALE. This fixes that

**Type of change**

- [X] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
