### PR TITLE
Make common chart naming more consistent

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources:
 type: library
-version: 6.8.0
+version: 6.8.1

--- a/charts/library/common/templates/lib/chart/_names.tpl
+++ b/charts/library/common/templates/lib/chart/_names.tpl
@@ -20,8 +20,14 @@ If release name contains chart name it will be used as a full name.
   {{- end -}}
   {{- if or .Values.fullnameOverride $globalFullNameOverride -}}
     {{- $name = default .Values.fullnameOverride $globalFullNameOverride -}}
+  {{- else if .Values.ixChartContext -}}
+    {{- $name = printf "%s-%s" .Release.Name $name -}}
   {{- else -}}
+    {{- if contains $name .Release.Name -}}
+      {{- $name = .Release.Name -}}
+    {{- else -}}
       {{- $name = printf "%s-%s" .Release.Name $name -}}
+    {{- end -}}
   {{- end -}}
   {{- trunc 63 $name | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/library/common/templates/lib/chart/_names.tpl
+++ b/charts/library/common/templates/lib/chart/_names.tpl
@@ -21,11 +21,7 @@ If release name contains chart name it will be used as a full name.
   {{- if or .Values.fullnameOverride $globalFullNameOverride -}}
     {{- $name = default .Values.fullnameOverride $globalFullNameOverride -}}
   {{- else -}}
-    {{- if contains $name .Release.Name -}}
-      {{- $name = .Release.Name -}}
-    {{- else -}}
       {{- $name = printf "%s-%s" .Release.Name $name -}}
-    {{- end -}}
   {{- end -}}
   {{- trunc 63 $name | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
**Description**
We currently use different naming depending on the App name during install.
This makes it needlessly more complicated to document internal DNS names for users.

This patch should make the naming a lot more consistent.

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
