### PR TITLE
Fix quickstart link in README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -26,7 +26,7 @@ All our apps are supposed to work together, be easy to setup using the TrueNAS U
 Installing TrueCharts within TrueNAS SCALE, is possible using the TrueNAS SCALE Catalog list.
 
 For more information:
-https://truecharts.org/manual/adding-truecharts/
+https://truecharts.org/manual/Quick-Start%20Guides/02-Adding-TrueCharts/
 
 ### Support
 


### PR DESCRIPTION
**Description**

Fixed the link to truecharts.org on how to add Truecharts in README

NB: might need to do that in the gh-pages branch too, but I am not sure where to do that.

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning