### PR TITLE
only set group when setting permissions

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 6.8.1
+version: 6.8.2

--- a/charts/library/common/templates/classes/_mountPermissions.tpl
+++ b/charts/library/common/templates/classes/_mountPermissions.tpl
@@ -5,13 +5,10 @@ before chart installation.
 {{- define "common.class.mountPermissions" -}}
   {{- if .Values.persistence -}}
     {{- $jobName := include "common.names.fullname" . -}}
-    {{- $user := 568 -}}
     {{- $group := 568 -}}
     {{- if .Values.env -}}
-        {{- $user = dig "PUID" $user .Values.env -}}
         {{- $group = dig "PGID" $group .Values.env -}}
     {{- end -}}
-    {{- $user = dig "runAsUser" $user .Values.podSecurityContext -}}
     {{- $group = dig "fsGroup" $group .Values.podSecurityContext -}}
     {{- $hostPathMounts := dict -}}
     {{- range $name, $mount := .Values.persistence -}}
@@ -45,7 +42,7 @@ spec:
             - -c
             - |
               {{- range $_, $hpm := $hostPathMounts }}
-              chown -R {{ printf "%d:%d %s" (int $user) (int $group) $hpm.mountPath }}
+              chown -R {{ printf ":%d %s" (int $group) $hpm.mountPath }}
               {{- end }}
           volumeMounts:
             {{- range $name, $hpm := $hostPathMounts }}

--- a/charts/library/common/tests/permissions_job_test.go
+++ b/charts/library/common/tests/permissions_job_test.go
@@ -139,7 +139,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
         "DefaultPermissionsForMultipleMounts": {
             values: baseValues,
             expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R 568:568 /config\nchown -R 568:568 /data\n",
+                "/bin/sh", "-c", "chown -R :568 /config\nchown -R 568:568 /data\n",
             },
         },
         "DefaultPermissionsForDisabledpodSecurityContext": {
@@ -147,7 +147,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
                 "podSecurityContext.allowPrivilegeEscalation=false",
             ),
             expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R 568:568 /config\nchown -R 568:568 /data\n",
+                "/bin/sh", "-c", "chown -R :568 /config\nchown -R 568:568 /data\n",
             },
         },
         "PermissionsForFsGroup": {
@@ -155,33 +155,15 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
                 "podSecurityContext.fsGroup=666",
             ),
             expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R 568:666 /config\nchown -R 568:666 /data\n",
+                "/bin/sh", "-c", "chown -R :666 /config\nchown -R 568:666 /data\n",
             },
         },
-        "PermissionsForRunAsUser": {
+        "PermissionsForPgid": {
             values: append(baseValues,
-                "podSecurityContext.runAsUser=999",
-            ),
-            expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R 999:568 /config\nchown -R 999:568 /data\n",
-            },
-        },
-        "PermissionsForRunAsUserAndFsGroup": {
-            values: append(baseValues,
-                "podSecurityContext.runAsUser=999",
-                "podSecurityContext.fsGroup=666",
-            ),
-            expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R 999:666 /config\nchown -R 999:666 /data\n",
-            },
-        },
-        "PermissionsForPgidPuid": {
-            values: append(baseValues,
-                "env.PUID=999",
                 "env.PGID=666",
             ),
             expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R 999:666 /config\nchown -R 999:666 /data\n",
+                "/bin/sh", "-c", "chown -R :666 /config\nchown -R 999:666 /data\n",
             },
         },
     }

--- a/charts/library/common/tests/permissions_job_test.go
+++ b/charts/library/common/tests/permissions_job_test.go
@@ -139,7 +139,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
         "DefaultPermissionsForMultipleMounts": {
             values: baseValues,
             expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R :568 /config\nchown -R 568:568 /data\n",
+                "/bin/sh", "-c", "chown -R :568 /config\nchown -R :568 /data\n",
             },
         },
         "DefaultPermissionsForDisabledpodSecurityContext": {
@@ -147,7 +147,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
                 "podSecurityContext.allowPrivilegeEscalation=false",
             ),
             expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R :568 /config\nchown -R 568:568 /data\n",
+                "/bin/sh", "-c", "chown -R :568 /config\nchown -R :568 /data\n",
             },
         },
         "PermissionsForFsGroup": {
@@ -155,7 +155,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
                 "podSecurityContext.fsGroup=666",
             ),
             expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R :666 /config\nchown -R 568:666 /data\n",
+                "/bin/sh", "-c", "chown -R :666 /config\nchown -R :666 /data\n",
             },
         },
         "PermissionsForPgid": {
@@ -163,7 +163,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
                 "env.PGID=666",
             ),
             expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R :666 /config\nchown -R 999:666 /data\n",
+                "/bin/sh", "-c", "chown -R :666 /config\nchown -R :666 /data\n",
             },
         },
     }


### PR DESCRIPTION
**Description**
This removes setting the user from the automatic permissions system, as it isn't required at all.
This also makes sure it's in-line with the automatic permissions using fsgroup on PVC

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
