### PR TITLE
try to fix pre-install quoting errors

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 6.9.1
+version: 6.9.2

--- a/charts/library/common/templates/classes/_mountPermissions.tpl
+++ b/charts/library/common/templates/classes/_mountPermissions.tpl
@@ -42,7 +42,7 @@ spec:
             - -c
             - |
               {{- range $_, $hpm := $hostPathMounts }}
-              chown -R {{ printf ":%d %s" (int $group) $hpm.mountPath }}
+              chown -R {{ printf ":%d %s" (int $group) ( $hpm.mountPath | quote ) }}
               {{- end }}
           volumeMounts:
             {{- range $name, $hpm := $hostPathMounts }}

--- a/charts/library/common/templates/classes/_mountPermissions.tpl
+++ b/charts/library/common/templates/classes/_mountPermissions.tpl
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: set-mount-permissions
           image: alpine:3.3
-          command: ["/bin/bash", "-c"]
+          command: ["/bin/sh", "-c"]
           args:
             {{- range $_, $hpm := $hostPathMounts }}
             - chown -R {{ printf ":%d %s" (int $group) ( $hpm.mountPath | quote ) }}

--- a/charts/library/common/templates/classes/_mountPermissions.tpl
+++ b/charts/library/common/templates/classes/_mountPermissions.tpl
@@ -40,7 +40,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             {{- range $_, $hpm := $hostPathMounts }}
-            - chown -R {{ printf ":%d %s" (int $group) ( $hpm.mountPath | quote ) }}
+            - chown -R {{ printf ":%d %s" (int $group) ( $hpm.mountPath | squote ) }}
             {{- end }}
           volumeMounts:
             {{- range $name, $hpm := $hostPathMounts }}

--- a/charts/library/common/templates/classes/_mountPermissions.tpl
+++ b/charts/library/common/templates/classes/_mountPermissions.tpl
@@ -37,13 +37,11 @@ spec:
       containers:
         - name: set-mount-permissions
           image: alpine:3.3
-          command:
-            - /bin/sh
-            - -c
-            - |
-              {{- range $_, $hpm := $hostPathMounts }}
-              chown -R {{ printf ":%d %s" (int $group) ( $hpm.mountPath | quote ) }}
-              {{- end }}
+          command: ["/bin/bash", "-c"]
+          args:
+            {{- range $_, $hpm := $hostPathMounts }}
+            - chown -R {{ printf ":%d %s" (int $group) ( $hpm.mountPath | quote ) }}
+            {{- end }}
           volumeMounts:
             {{- range $name, $hpm := $hostPathMounts }}
             - name: {{ printf "hostpathmounts-%s" $name }}

--- a/charts/library/common/tests/permissions_job_test.go
+++ b/charts/library/common/tests/permissions_job_test.go
@@ -192,6 +192,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
 
             containers, _ := jobManifest.Path("spec.template.spec.containers").Children()
             command, _ := containers[0].Path("command").Children()
+            args, _ := containers[0].Path("command").Children()
             if tc.expectedCommand != nil {
                 actualCommand := []string{}
 

--- a/charts/library/common/tests/permissions_job_test.go
+++ b/charts/library/common/tests/permissions_job_test.go
@@ -192,7 +192,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
 
             containers, _ := jobManifest.Path("spec.template.spec.containers").Children()
             command, _ := containers[0].Path("command").Children()
-            args, _ := containers[0].Path("command").Children()
+            args, _ := containers[0].Path("args").Children()
             if tc.expectedCommand != nil {
                 actualCommand := []string{}
 

--- a/charts/library/common/tests/permissions_job_test.go
+++ b/charts/library/common/tests/permissions_job_test.go
@@ -135,6 +135,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
     tests := map[string]struct {
         values          []string
         expectedCommand []string
+        expectedArgs []string
     }{
         "DefaultPermissionsForMultipleMounts": {
             values: baseValues,

--- a/charts/library/common/tests/permissions_job_test.go
+++ b/charts/library/common/tests/permissions_job_test.go
@@ -141,6 +141,9 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
             expectedCommand: []string{
                 "/bin/sh", "-c",
             },
+            expectedArgs: []string{
+                "chown -R :568 '/config'", "chown -R :568 '/data'",
+            },
         },
         "DefaultPermissionsForDisabledpodSecurityContext": {
             values: append(baseValues,
@@ -148,6 +151,9 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
             ),
             expectedCommand: []string{
                 "/bin/sh", "-c",
+            },
+            expectedArgs: []string{
+                "chown -R :568 '/config'", "chown -R :568 '/data'",
             },
         },
         "PermissionsForFsGroup": {
@@ -157,6 +163,9 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
             expectedCommand: []string{
                 "/bin/sh", "-c",
             },
+            expectedArgs: []string{
+                "chown -R :666 '/config'", "chown -R :666 '/data'",
+            },
         },
         "PermissionsForPgid": {
             values: append(baseValues,
@@ -164,6 +173,9 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
             ),
             expectedCommand: []string{
                 "/bin/sh", "-c",
+            },
+            expectedArgs: []string{
+                "chown -R :666 '/config'", "chown -R :666 '/data'",
             },
         },
     }
@@ -189,6 +201,17 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
                 suite.Assertions.EqualValues(tc.expectedCommand, actualCommand)
             } else {
                 suite.Assertions.Empty(command)
+            }
+            if tc.expectedArgs != nil {
+                actualArgs := []string{}
+
+                for _, v := range args {
+                    actualArgs = append(actualArgs, v.Data().(string))
+                }
+
+                suite.Assertions.EqualValues(tc.expectedArgs, actualArgs)
+            } else {
+                suite.Assertions.Empty(args)
             }
         })
     }

--- a/charts/library/common/tests/permissions_job_test.go
+++ b/charts/library/common/tests/permissions_job_test.go
@@ -139,7 +139,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
         "DefaultPermissionsForMultipleMounts": {
             values: baseValues,
             expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R :568 /config\nchown -R :568 /data\n",
+                "/bin/sh", "-c",
             },
         },
         "DefaultPermissionsForDisabledpodSecurityContext": {
@@ -147,7 +147,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
                 "podSecurityContext.allowPrivilegeEscalation=false",
             ),
             expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R :568 /config\nchown -R :568 /data\n",
+                "/bin/sh", "-c",
             },
         },
         "PermissionsForFsGroup": {
@@ -155,7 +155,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
                 "podSecurityContext.fsGroup=666",
             ),
             expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R :666 /config\nchown -R :666 /data\n",
+                "/bin/sh", "-c",
             },
         },
         "PermissionsForPgid": {
@@ -163,7 +163,7 @@ func (suite *PermissionsJobTestSuite) TestCommand() {
                 "env.PGID=666",
             ),
             expectedCommand: []string{
-                "/bin/sh", "-c", "chown -R :666 /config\nchown -R :666 /data\n",
+                "/bin/sh", "-c",
             },
         },
     }


### PR DESCRIPTION
**Description**
When using a mountPath with spaces, the chown inside the pre-install permissions job, freaks out because the path isn't quoted correctly.
This PR adds the required quoting.

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
