### PR TITLE
[common] allow the use of tpl's for envFrom

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 6.9.3
+version: 6.10.0

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 6.9.2
+version: 6.9.3

--- a/charts/library/common/templates/lib/controller/_container.tpl
+++ b/charts/library/common/templates/lib/controller/_container.tpl
@@ -40,6 +40,10 @@
         secretKeyRef:
           name: {{ tpl $value.secretKeyRef.name $ | quote }}
           key: {{ tpl $value.secretKeyRef.key $ | quote }}
+        {{- else if $value.configMapRef }}
+        configMapRef:
+          name: {{ tpl $value.configMapRef.name $ | quote }}
+          key: {{ tpl $value.configMapRef.key $ | quote }}
         {{- else }}
         {{- $value | toYaml | nindent 8 }}
         {{- end }}
@@ -79,13 +83,21 @@
   {{- end }}
   {{- if or .Values.envFrom .Values.secret }}
   envFrom:
-    {{- with .Values.envFrom }}
-      {{- toYaml . | nindent 4 }}
+  {{- range $key, $value := .Values.envFrom }}
+    {{- if  $value.secretKeyRef }}
+    - secretKeyRef:
+      name: {{ tpl $value.secretKeyRef.name $ | quote }}
+    {{- else if  $value.configMapRef }}
+    - configMapRef:
+      name: {{ tpl $value.configMapRef.name $ | quote }}
+    {- else }}
+      {{- toYaml $value | nindent 4 }}
     {{- end }}
-    {{- if .Values.secret }}
-    - secretRef:
-        name: {{ include "common.names.fullname" . }}
-    {{- end }}
+  {{- end }}
+  {{- if .Values.secret }}
+  - secretRef:
+      name: {{ include "common.names.fullname" . }}
+  {{- end }}
   {{- end }}
   {{- include "common.controller.ports" . | trim | nindent 2 }}
   {{- with (include "common.controller.volumeMounts" . | trim) }}


### PR DESCRIPTION
**Description**
Common has an issue where the name of the secret/configmap cannot be set using tpl's, this needlessly complicates things.

**Type of change**

- [X] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
