### PR TITLE
Add labels to more common objects and add names.fqdn

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 6.13.1
+version: 6.13.2

--- a/charts/library/common/templates/_networkPolicy.tpl
+++ b/charts/library/common/templates/_networkPolicy.tpl
@@ -7,6 +7,8 @@ Blueprint for the NetworkPolicy object that can be included in the addon.
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
   name: {{ include "common.names.fullname" . }}
 spec:
   podSelector:

--- a/charts/library/common/templates/_rbac.tpl
+++ b/charts/library/common/templates/_rbac.tpl
@@ -10,6 +10,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . -}}
   labels:
+    {{- include "common.labels" . | nindent 4 }}
     {{- with .Values.rbac.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -27,6 +28,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . -}}
   labels:
+    {{- include "common.labels" . | nindent 4 }}
     {{- with .Values.rbac.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/library/common/templates/configmaps/_portal.tpl
+++ b/charts/library/common/templates/configmaps/_portal.tpl
@@ -71,7 +71,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: portal
-  labels: {{ include "common.labels" . | nindent 4 }}
+  labels:
+  {{ include "common.labels" . | nindent 4 }}
   annotations:
     rollme: {{ randAlphaNum 5 | quote }}
 data:

--- a/charts/library/common/templates/lib/chart/_names.tpl
+++ b/charts/library/common/templates/lib/chart/_names.tpl
@@ -56,3 +56,10 @@ If release name contains chart name it will be used as a full name.
     {{- fail (printf "Not a valid controller.type (%s)" .Values.controller.type) -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Create the "name" + "." + "namespace" fqdn
+*/}}
+{{- define "common.names.fqdn" -}}
+{{- printf "%s.%s" (include "k8s-gateway.fullname" .) .Release.Namespace | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/library/common/templates/lib/chart/_names.tpl
+++ b/charts/library/common/templates/lib/chart/_names.tpl
@@ -61,5 +61,5 @@ If release name contains chart name it will be used as a full name.
 Create the "name" + "." + "namespace" fqdn
 */}}
 {{- define "common.names.fqdn" -}}
-{{- printf "%s.%s" (include "k8s-gateway.fullname" .) .Release.Namespace | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s.%s" (include "common.names.fullname" .) .Release.Namespace | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
**Description**
This PR adds the default labels to more common-chart objects and also adds an option to print the chart-fullname+.namespace using common.names.fqdn. 

**Type of change**

- [X] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
