### PR TITLE
move default middleware location to default namespace

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 6.13.6
+version: 6.13.7

--- a/charts/library/common/templates/classes/_ingress.tpl
+++ b/charts/library/common/templates/classes/_ingress.tpl
@@ -26,21 +26,26 @@ within the common library.
 
   {{- $isStable := include "common.capabilities.ingress.isStable" . }}
 
+  {{- $mddwrNamespace := "default" }}
+  {{- if $values.ingressClassName }}
+  {{- $mddwrNamespace := ( printf "ix-%s" $values.ingressClassName ) }}
+  {{- end }}
+
   {{- $fixedMiddlewares := "" }}
   {{ range $index, $fixedMiddleware := $values.fixedMiddlewares }}
       {{- if $index }}
-      {{ $fixedMiddlewares = ( printf "%v, %v-%v@%v" $fixedMiddlewares "traefikmiddlewares" $fixedMiddleware "kubernetescrd" ) }}
+      {{ $fixedMiddlewares = ( printf "%v, %v-%v@%v" $fixedMiddlewares $mddwrNamespace $fixedMiddleware "kubernetescrd" ) }}
       {{- else }}
-      {{ $fixedMiddlewares = ( printf "%v-%v@%v" "traefikmiddlewares" $fixedMiddleware "kubernetescrd" ) }}
+      {{ $fixedMiddlewares = ( printf "%v-%v@%v" $mddwrNamespace $fixedMiddleware "kubernetescrd" ) }}
       {{- end }}
   {{ end }}
 
   {{- $middlewares := "" }}
   {{ range $index, $middleware := $values.middlewares }}
       {{- if $index }}
-      {{ $middlewares = ( printf "%v, %v-%v@%v" $middlewares "traefikmiddlewares" $middleware "kubernetescrd" ) }}
+      {{ $middlewares = ( printf "%v, %v-%v@%v" $middlewares $mddwrNamespace $middleware "kubernetescrd" ) }}
       {{- else }}
-      {{ $middlewares = ( printf "%v-%v@%v" "traefikmiddlewares" $middleware "kubernetescrd" ) }}
+      {{ $middlewares = ( printf "%v-%v@%v" $mddwrNamespace $middleware "kubernetescrd" ) }}
       {{- end }}
   {{ end }}
 

--- a/charts/library/common/templates/configmaps/_portal.tpl
+++ b/charts/library/common/templates/configmaps/_portal.tpl
@@ -28,8 +28,7 @@
   {{- end }}
 {{- end }}
 
-{{- $namespace := "traefikmiddlewares" }}
-
+{{- $namespace := "default" }}
 {{- if $ingr.ingressClassName }}
 {{- $namespace := ( printf "ix-%s" $ingr.ingressClassName ) }}
 {{- end }}

--- a/charts/stable/traefik/Chart.yaml
+++ b/charts/stable/traefik/Chart.yaml
@@ -22,4 +22,4 @@ sources:
 - https://github.com/traefik/traefik-helm-chart
 - https://traefik.io/
 type: application
-version: 7.0.2
+version: 7.0.3

--- a/charts/stable/traefik/templates/_portalhook.tpl
+++ b/charts/stable/traefik/templates/_portalhook.tpl
@@ -3,7 +3,7 @@
 {{- if .Values.portalhook.enabled }}
 {{- $namespace := ( printf "ix-%s" .Release.Name ) }}
 {{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "traefikmiddlewares" }}
+{{- $namespace = "default" }}
 {{- end }}
 ---
 
@@ -19,7 +19,6 @@ data:
   {{- $_ := set $ports $name $value }}
   {{- end }}
   {{- end }}
-  websecureport: {{ $ports.websecure.exposedPort | quote }}
   {{- range $name, $value := $ports }}
   {{ $name }}: {{ $value.port | quote }}
   {{- end }}

--- a/charts/stable/traefik/templates/middleware-namespace.yaml
+++ b/charts/stable/traefik/templates/middleware-namespace.yaml
@@ -1,7 +1,0 @@
-{{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: traefikmiddlewares
-  namespace: traefikmiddlewares
-{{- end }}

--- a/charts/stable/traefik/templates/middlewares/basic-middleware.yaml
+++ b/charts/stable/traefik/templates/middlewares/basic-middleware.yaml
@@ -1,7 +1,7 @@
 {{- $values := .Values }}
 {{- $namespace := ( printf "ix-%s" .Release.Name ) }}
 {{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "traefikmiddlewares" }}
+{{- $namespace = "default" }}
 {{- end }}
 ---
 apiVersion: traefik.containo.us/v1alpha1

--- a/charts/stable/traefik/templates/middlewares/basicauth.yaml
+++ b/charts/stable/traefik/templates/middlewares/basicauth.yaml
@@ -1,7 +1,7 @@
 {{- $values := .Values }}
 {{- $namespace := ( printf "ix-%s" .Release.Name ) }}
 {{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "traefikmiddlewares" }}
+{{- $namespace = "default" }}
 {{- end }}
 {{ range $index, $middlewareData := .Values.middlewares.basicAuth }}
 ---

--- a/charts/stable/traefik/templates/middlewares/chain.yaml
+++ b/charts/stable/traefik/templates/middlewares/chain.yaml
@@ -1,7 +1,7 @@
 {{- $values := .Values }}
 {{- $namespace := ( printf "ix-%s" .Release.Name ) }}
 {{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "traefikmiddlewares" }}
+{{- $namespace = "default" }}
 {{- end }}
 {{ range $index, $middlewareData := .Values.middlewares.chain }}
 

--- a/charts/stable/traefik/templates/middlewares/forwardauth.yaml
+++ b/charts/stable/traefik/templates/middlewares/forwardauth.yaml
@@ -1,7 +1,7 @@
 {{- $values := .Values }}
 {{- $namespace := ( printf "ix-%s" .Release.Name ) }}
 {{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "traefikmiddlewares" }}
+{{- $namespace = "default" }}
 {{- end }}
 {{ range $index, $middlewareData := .Values.middlewares.forwardAuth }}
 ---

--- a/charts/stable/traefik/templates/middlewares/ratelimit.yaml
+++ b/charts/stable/traefik/templates/middlewares/ratelimit.yaml
@@ -1,7 +1,7 @@
 {{- $values := .Values }}
 {{- $namespace := ( printf "ix-%s" .Release.Name ) }}
 {{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "traefikmiddlewares" }}
+{{- $namespace = "default" }}
 {{- end }}
 {{ range $index, $middlewareData := .Values.middlewares.rateLimit }}
 

--- a/charts/stable/traefik/templates/middlewares/redirectScheme.yaml
+++ b/charts/stable/traefik/templates/middlewares/redirectScheme.yaml
@@ -1,7 +1,7 @@
 {{- $values := .Values }}
 {{- $namespace := ( printf "ix-%s" .Release.Name ) }}
 {{- if or ( not .Values.ingressClass.enabled ) ( and ( .Values.ingressClass.enabled ) ( .Values.ingressClass.isDefaultClass ) ) }}
-{{- $namespace = "traefikmiddlewares" }}
+{{- $namespace = "default" }}
 {{- end }}
 {{ range $index, $middlewareData := .Values.middlewares.redirectScheme }}
 


### PR DESCRIPTION
**Description**
Creating a seperate namespace for middlewares creates all kinds of issues and  complications.
Lets keep them in `default` namespace if ingressClass is either default or not-enabled.

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Manuall template readout for different combinations of settings

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
