### PR TITLE
fix: Add initcontainer to force refresh TRUSTED_DOMAINS

### DIFF
--- a/charts/stable/nextcloud/Chart.yaml
+++ b/charts/stable/nextcloud/Chart.yaml
@@ -33,4 +33,4 @@ sources:
 - https://github.com/nextcloud/docker
 - https://github.com/nextcloud/helm
 type: application
-version: 3.7.14
+version: 3.7.15

--- a/charts/stable/nextcloud/templates/_configmap.tpl
+++ b/charts/stable/nextcloud/templates/_configmap.tpl
@@ -3,13 +3,15 @@
 
 {{- $hosts := "" }}
 {{- if .Values.ingress.main.enabled }}
-{{ range $index, $host := .Values.ingress.main.hosts }}
+{{- range .Values.ingress }}
+{{- range $index, $host := .hosts }}
     {{- if $index }}
     {{ $hosts = ( printf "%v %v" $hosts $host.host ) }}
     {{- else }}
     {{ $hosts = ( printf "%s" $host.host ) }}
     {{- end }}
-{{ end }}
+{{- end }}
+{{- end }}
 {{- end }}
 ---
 apiVersion: v1

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -81,6 +81,30 @@ initContainers:
           secretKeyRef:
             name: dbcreds
             key: plainhost
+  - name: injectconfig
+    image: nextcloud:22.1.1
+    command:
+      - "su"
+      - "-p"
+      - "www-data"
+      - "-s"
+      - "/bin/sh"
+      - "-c"
+    args:
+      - if [ -f /var/www/html/occ ]; then
+          if [ -n "${NEXTCLOUD_TRUSTED_DOMAINS+x}" ]; then
+            echo "setting trusted domains…";
+            NC_TRUSTED_DOMAIN_IDX=1;
+            for DOMAIN in $NEXTCLOUD_TRUSTED_DOMAINS ; do
+              DOMAIN=$(echo "$DOMAIN" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//');
+              php /var/www/html/occ config:system:set trusted_domains $NC_TRUSTED_DOMAIN_IDX --value=$DOMAIN;
+              NC_TRUSTED_DOMAIN_IDX=$(($NC_TRUSTED_DOMAIN_IDX+1));
+            done;
+          fi;
+        fi;
+    volumeMounts:
+      - mountPath: /var/www/html
+        name: data
 
 
 podSecurityContext:

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -83,6 +83,9 @@ initContainers:
             key: plainhost
   - name: injectconfig
     image: nextcloud:22.1.1
+    envFrom:
+      - configMapRef:
+          name: nextcloudconfig
     command:
       - "su"
       - "-p"


### PR DESCRIPTION
**Description**
This adds a init container, that refreshes loading the TRUSTED_DOMAINS every restart/
This should ensure our config actually sticks.

Fixes #920

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
