### PR TITLE
fix: ensure supplementalgroups when using devices are actually added

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 6.13.9
+version: 6.13.10

--- a/charts/library/common/templates/lib/chart/_values.tpl
+++ b/charts/library/common/templates/lib/chart/_values.tpl
@@ -129,25 +129,29 @@
   {{- $_ := set .Values.securityContext "privileged" true -}}
   {{- end }}
 
-  {{/* save supplementalGroups to placeholder variable */}}
-  {{- $supGroups := list }}
-  {{ if .Values.podSecurityContext.supplementalGroups }}
-  {{- $supGroups = .Values.podSecurityContext.supplementalGroups }}
+  {{/* save supplementalGroups to placeholder variables */}}
+  {{- $fixedGroups := list 568 }}
+  {{- $valuegroups := list }}
+  {{- $devGroups := list }}
+  {{- $gpuGroups := list }}
+
+  {{/* put user-entered supplementalgroups in placeholder variable */}}
+  {{- if .Values.podSecurityContext.supplementalGroups }}
+  {{- $valuegroups = .Values.podSecurityContext.supplementalGroups }}
   {{- end }}
 
   {{/* Append requered groups to supplementalGroups when deviceList is used */}}
   {{- if .Values.deviceList}}
-  {{- $devGroups := list 5 20 24 }}
-  {{- $supGroups := list ( concat $supGroups $devGroups ) }}
+  {{- $devGroups = list 5 20 24 }}
   {{- end }}
 
   {{/* Append requered groups to supplementalGroups when scaleGPU is used */}}
   {{- if .Values.scaleGPU }}
-  {{- $gpuGroups := list 44 107 }}
-  {{- $supGroups := list ( concat $supGroups $gpuGroups ) }}
+  {{- $gpuGroups = list 44 107 }}
   {{- end }}
 
-  {{/* write appended supplementalGroups to .Values */}}
+  {{/* combine and write all supplementalGroups to .Values */}}
+  {{- $supGroups := concat $fixedGroups $valuegroups $devGroups $gpuGroups }}
   {{- $_ := set .Values.podSecurityContext "supplementalGroups" $supGroups -}}
 
   {{/* merge serviceList with service */}}


### PR DESCRIPTION
**Description**
Also adds 568 as a supplemental group that is always present, just in case.

#940

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [X] I have added tests to this description that prove my fix is effective or that my feature works
- [X] I increased versions for any altered app according to semantic versioning
