### PR TITLE
fix: correct fireflyiii ports and services

### DIFF
--- a/charts/stable/fireflyiii/SCALE/questions.yaml
+++ b/charts/stable/fireflyiii/SCALE/questions.yaml
@@ -327,7 +327,7 @@ questions:
                             label: "Container Port"
                             schema:
                               type: int
-                              default: 51080
+                              default: 8080
                               editable: true
                               required: true
                           - variable: nodePort
@@ -338,7 +338,6 @@ questions:
                               min: 9000
                               max: 65535
                               default: 36048
-
 
   - variable: serviceList
     label: "Additional Services"

--- a/charts/stable/fireflyiii/values.yaml
+++ b/charts/stable/fireflyiii/values.yaml
@@ -19,14 +19,6 @@ service:
     ports:
       main:
         port: 8080
-  tcp:
-    enabled: true
-    type: ClusterIP
-    ports:
-      tcp:
-        enabled: true
-        port: 51080
-        protocol: TCP
 
 initContainers:
   - name: init-postgresdb


### PR DESCRIPTION
**Description**
Fireflyiii ports where all-over-the-place.
Adapted them to comply with the firelfyiii manual

As it fixes the UI showing different numbers by default, this fix what is actually displayed in the following issue, hence:
Fixes #943

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
