### PR TITLE
fix: Inject vaultwarden websocket part into ingress

### DIFF
--- a/charts/stable/vaultwarden/templates/common.yaml
+++ b/charts/stable/vaultwarden/templates/common.yaml
@@ -1,11 +1,38 @@
 {{/* Make sure all variables are set properly */}}
 {{- include "common.values.setup" . }}
 
-{{/* Render the templates */}}
-{{ include "common.all" . }}
 
 {{/* Render configmap for vaultwarden */}}
 {{- include "vaultwarden.configmap" . }}
 
 {{/* Render secrets for vaultwarden */}}
 {{- include "vaultwarden.secrets" . }}
+
+{{/* Define path for websocket */}}
+{{- define "vaultwarden.websocket" -}}
+path: "/notifications/hub"
+# -- Ignored if not kubeVersion >= 1.14-0
+pathType: Prefix
+service:
+  # -- Overrides the service name reference for this path
+  name: ws
+  port: {{ .Values.service.ws.ports.ws.port }}
+{{- end -}}
+
+{{/* inject websocket path to all main ingress hosts*/}}
+{{- define "vaultwarden.websocketinjector" -}}
+{{- $path := list (include "vaultwarden.websocket" . | fromYaml) -}}
+{{- if .Values.ingress.main.enabled }}
+{{- range .Values.ingress.main.hosts }}
+{{- $newpaths := list }}
+{{- $newpaths := concat .paths $path }}
+{{- $_ := set . "paths" ( deepCopy $newpaths ) -}}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/* inject websocket paths in ingress */}}
+{{- include "vaultwarden.websocketinjector" . }}
+
+{{/* Render the templates */}}
+{{ include "common.all" . }}

--- a/charts/stable/vaultwarden/values.yaml
+++ b/charts/stable/vaultwarden/values.yaml
@@ -21,6 +21,74 @@ service:
 
 env: {}
 
+# -- Configure the ingresses for the chart here.
+# Additional ingresses can be added by adding a dictionary key similar to the 'main' ingress.
+# @default -- See below
+ingress:
+  main:
+    # -- Enables or disables the ingress
+    enabled: true
+
+    # -- Make this the primary ingress (used in probes, notes, etc...).
+    # If there is more than 1 ingress, make sure that only 1 ingress is marked as primary.
+    primary: true
+
+    # -- Override the name suffix that is used for this ingress.
+    nameOverride:
+
+    # -- List of middlewares in the traefikmiddlewares k8s namespace to add automatically
+    # Creates an annotation with the middlewares and appends k8s and traefik namespaces to the middleware names
+    # Primarily used for TrueNAS SCALE to add additional (seperate) middlewares without exposing them to the end-user
+    fixedMiddlewares:
+      - chain-basic
+
+    # -- Additional List of middlewares in the traefikmiddlewares k8s namespace to add automatically
+    # Creates an annotation with the middlewares and appends k8s and traefik namespaces to the middleware names
+    middlewares: []
+    annotationsList: []
+    # - name: somename
+    #   value: somevalue
+    # -- Provide additional annotations which may be required.
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+
+    labelsList: []
+    # - name: somename
+    #   value: somevalue
+    # -- Set labels on the deployment/statefulset/daemonset
+    # -- Provide additional labels which may be required.
+    # -- Provide additional labels which may be required.
+    labels: {}
+
+    # -- Set the ingressClass that is used for this ingress.
+    # Requires Kubernetes >=1.19
+    ingressClassName:  # "nginx"
+
+    ## Configure the hosts for the ingress
+    hosts:
+      -  # -- Host address. Helm template can be passed.
+        host: chart-example.local
+        ## Configure the paths for the host
+        paths:
+          -  # -- Path.  Helm template can be passed.
+            path: /
+            # -- Ignored if not kubeVersion >= 1.14-0
+            pathType: Prefix
+            service:
+              # -- Overrides the service name reference for this path
+              name:
+              # -- Overrides the service port reference for this path
+              port:
+
+    # -- Configure TLS for the ingress. Both secretName and hosts can process a Helm template.
+    tls: []
+    #  - secretName: chart-example-tls
+    # -- Create a secret from a GUI selected TrueNAS SCALE certificate
+    #    scaleCert: true
+    #    hosts:
+    #      - chart-example.local
+
 initContainers:
   - name: init-postgresdb
     image: postgres:13.1


### PR DESCRIPTION
**Description**
Vaultwarden was not forwarding the websocket connections correctly using ingress.
This PR injects an extra path into ingress to deal with this. This is a bit hacky, but in a lot of containers this would already be done by the container itself anyway.
Fixes #928

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
