### PR TITLE
fix: move runAsNonRoot to container securityContext to allow root sidecarts

### DIFF
--- a/charts/incubator/custom-app/SCALE/questions.yaml
+++ b/charts/incubator/custom-app/SCALE/questions.yaml
@@ -1015,6 +1015,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1022,11 +1027,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/incubator/oscam/SCALE/questions.yaml
+++ b/charts/incubator/oscam/SCALE/questions.yaml
@@ -980,6 +980,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/incubator/sogo/Chart.yaml
+++ b/charts/incubator/sogo/Chart.yaml
@@ -27,4 +27,4 @@ name: sogo
 sources:
 - https://www.sogo.nu/
 type: application
-version: 2.0.0
+version: 2.0.1

--- a/charts/incubator/sogo/SCALE/questions.yaml
+++ b/charts/incubator/sogo/SCALE/questions.yaml
@@ -1469,6 +1469,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -18,4 +18,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 7.0.0
+version: 7.0.1

--- a/charts/library/common/templates/lib/controller/_autopermissions.yaml
+++ b/charts/library/common/templates/lib/controller/_autopermissions.yaml
@@ -24,6 +24,7 @@ before chart installation.
     runAsGroup: 0
     privileged: true
     allowPrivilegeEscalation: true
+    runAsRoot: true
   command:
     - "/bin/sh"
     - "-c"

--- a/charts/library/common/templates/lib/controller/_autopermissions.yaml
+++ b/charts/library/common/templates/lib/controller/_autopermissions.yaml
@@ -24,7 +24,7 @@ before chart installation.
     runAsGroup: 0
     privileged: true
     allowPrivilegeEscalation: true
-    runAsRoot: true
+    runAsNonRoot: false
   command:
     - "/bin/sh"
     - "-c"

--- a/charts/stable/airsonic/SCALE/questions.yaml
+++ b/charts/stable/airsonic/SCALE/questions.yaml
@@ -989,6 +989,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/appdaemon/SCALE/questions.yaml
+++ b/charts/stable/appdaemon/SCALE/questions.yaml
@@ -911,6 +911,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -918,11 +923,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/authelia/Chart.yaml
+++ b/charts/stable/authelia/Chart.yaml
@@ -38,4 +38,4 @@ sources:
 - https://github.com/authelia/chartrepo
 - https://github.com/authelia/authelia
 type: application
-version: 2.0.0
+version: 2.0.1

--- a/charts/stable/authelia/SCALE/questions.yaml
+++ b/charts/stable/authelia/SCALE/questions.yaml
@@ -1573,18 +1573,17 @@ questions:
           schema:
             type: boolean
             default: false
-
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
   - variable: podSecurityContext
     group: "Security and Permissions"
     label: "Pod Security Context"
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/bazarr/SCALE/questions.yaml
+++ b/charts/stable/bazarr/SCALE/questions.yaml
@@ -976,6 +976,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -983,11 +988,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/booksonic-air/SCALE/questions.yaml
+++ b/charts/stable/booksonic-air/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/calibre-web/SCALE/questions.yaml
+++ b/charts/stable/calibre-web/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/calibre/SCALE/questions.yaml
+++ b/charts/stable/calibre/SCALE/questions.yaml
@@ -1102,6 +1102,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/collabora-online/SCALE/questions.yaml
+++ b/charts/stable/collabora-online/SCALE/questions.yaml
@@ -904,6 +904,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/deconz/SCALE/questions.yaml
+++ b/charts/stable/deconz/SCALE/questions.yaml
@@ -1206,6 +1206,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/deepstack-cpu/SCALE/questions.yaml
+++ b/charts/stable/deepstack-cpu/SCALE/questions.yaml
@@ -1040,6 +1040,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/deluge/SCALE/questions.yaml
+++ b/charts/stable/deluge/SCALE/questions.yaml
@@ -1131,6 +1131,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/dizquetv/SCALE/questions.yaml
+++ b/charts/stable/dizquetv/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/duplicati/SCALE/questions.yaml
+++ b/charts/stable/duplicati/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/emby/SCALE/questions.yaml
+++ b/charts/stable/emby/SCALE/questions.yaml
@@ -984,6 +984,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -991,11 +996,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/esphome/SCALE/questions.yaml
+++ b/charts/stable/esphome/SCALE/questions.yaml
@@ -1079,6 +1079,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1086,11 +1091,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/fireflyiii/Chart.yaml
+++ b/charts/stable/fireflyiii/Chart.yaml
@@ -27,4 +27,4 @@ name: fireflyiii
 sources:
 - https://github.com/firefly-iii/firefly-iii/
 type: application
-version: 7.0.0
+version: 7.0.1

--- a/charts/stable/fireflyiii/SCALE/questions.yaml
+++ b/charts/stable/fireflyiii/SCALE/questions.yaml
@@ -986,6 +986,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -993,11 +998,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: false
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/flaresolverr/SCALE/questions.yaml
+++ b/charts/stable/flaresolverr/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/flood/SCALE/questions.yaml
+++ b/charts/stable/flood/SCALE/questions.yaml
@@ -982,6 +982,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -989,11 +994,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/focalboard/SCALE/questions.yaml
+++ b/charts/stable/focalboard/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/freeradius/SCALE/questions.yaml
+++ b/charts/stable/freeradius/SCALE/questions.yaml
@@ -959,6 +959,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/freshrss/SCALE/questions.yaml
+++ b/charts/stable/freshrss/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/gaps/SCALE/questions.yaml
+++ b/charts/stable/gaps/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/gonic/SCALE/questions.yaml
+++ b/charts/stable/gonic/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/grocy/SCALE/questions.yaml
+++ b/charts/stable/grocy/SCALE/questions.yaml
@@ -986,6 +986,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/handbrake/SCALE/questions.yaml
+++ b/charts/stable/handbrake/SCALE/questions.yaml
@@ -1203,6 +1203,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/haste-server/SCALE/questions.yaml
+++ b/charts/stable/haste-server/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -994,11 +999,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/healthchecks/SCALE/questions.yaml
+++ b/charts/stable/healthchecks/SCALE/questions.yaml
@@ -1010,6 +1010,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/heimdall/SCALE/questions.yaml
+++ b/charts/stable/heimdall/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/home-assistant/SCALE/questions.yaml
+++ b/charts/stable/home-assistant/SCALE/questions.yaml
@@ -1042,6 +1042,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/hyperion-ng/SCALE/questions.yaml
+++ b/charts/stable/hyperion-ng/SCALE/questions.yaml
@@ -1278,6 +1278,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1285,11 +1290,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/jackett/SCALE/questions.yaml
+++ b/charts/stable/jackett/SCALE/questions.yaml
@@ -1095,6 +1095,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1102,11 +1107,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/jellyfin/SCALE/questions.yaml
+++ b/charts/stable/jellyfin/SCALE/questions.yaml
@@ -984,6 +984,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -991,11 +996,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/k8s-gateway/SCALE/questions.yaml
+++ b/charts/stable/k8s-gateway/SCALE/questions.yaml
@@ -699,6 +699,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/kms/SCALE/questions.yaml
+++ b/charts/stable/kms/SCALE/questions.yaml
@@ -754,6 +754,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/komga/SCALE/questions.yaml
+++ b/charts/stable/komga/SCALE/questions.yaml
@@ -1085,6 +1085,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1092,11 +1097,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/lazylibrarian/SCALE/questions.yaml
+++ b/charts/stable/lazylibrarian/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/librespeed/SCALE/questions.yaml
+++ b/charts/stable/librespeed/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/lidarr/SCALE/questions.yaml
+++ b/charts/stable/lidarr/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/littlelink/SCALE/questions.yaml
+++ b/charts/stable/littlelink/SCALE/questions.yaml
@@ -1060,6 +1060,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/lychee/SCALE/questions.yaml
+++ b/charts/stable/lychee/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/mealie/SCALE/questions.yaml
+++ b/charts/stable/mealie/SCALE/questions.yaml
@@ -982,6 +982,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/mosquitto/SCALE/questions.yaml
+++ b/charts/stable/mosquitto/SCALE/questions.yaml
@@ -1097,6 +1097,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1104,11 +1109,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/mylar/SCALE/questions.yaml
+++ b/charts/stable/mylar/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -994,11 +999,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/navidrome/SCALE/questions.yaml
+++ b/charts/stable/navidrome/SCALE/questions.yaml
@@ -976,6 +976,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -983,11 +988,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/nextcloud/Chart.yaml
+++ b/charts/stable/nextcloud/Chart.yaml
@@ -33,4 +33,4 @@ sources:
 - https://github.com/nextcloud/docker
 - https://github.com/nextcloud/helm
 type: application
-version: 4.0.0
+version: 4.0.1

--- a/charts/stable/node-red/SCALE/questions.yaml
+++ b/charts/stable/node-red/SCALE/questions.yaml
@@ -976,6 +976,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -983,11 +988,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/nullserv/SCALE/questions.yaml
+++ b/charts/stable/nullserv/SCALE/questions.yaml
@@ -1078,6 +1078,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1085,11 +1090,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/nzbget/SCALE/questions.yaml
+++ b/charts/stable/nzbget/SCALE/questions.yaml
@@ -976,6 +976,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -983,11 +988,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/nzbhydra/SCALE/questions.yaml
+++ b/charts/stable/nzbhydra/SCALE/questions.yaml
@@ -976,6 +976,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -983,11 +988,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/octoprint/SCALE/questions.yaml
+++ b/charts/stable/octoprint/SCALE/questions.yaml
@@ -993,6 +993,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: deviceList
     label: "Mount USB devices"

--- a/charts/stable/omada-controller/SCALE/questions.yaml
+++ b/charts/stable/omada-controller/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/ombi/SCALE/questions.yaml
+++ b/charts/stable/ombi/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/openldap/SCALE/questions.yaml
+++ b/charts/stable/openldap/SCALE/questions.yaml
@@ -1015,6 +1015,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/organizr/SCALE/questions.yaml
+++ b/charts/stable/organizr/SCALE/questions.yaml
@@ -1097,6 +1097,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/overseerr/SCALE/questions.yaml
+++ b/charts/stable/overseerr/SCALE/questions.yaml
@@ -981,6 +981,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -988,11 +993,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/owncast/SCALE/questions.yaml
+++ b/charts/stable/owncast/SCALE/questions.yaml
@@ -1072,6 +1072,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/owncloud-ocis/SCALE/questions.yaml
+++ b/charts/stable/owncloud-ocis/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/pgadmin/SCALE/questions.yaml
+++ b/charts/stable/pgadmin/SCALE/questions.yaml
@@ -1001,6 +1001,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"

--- a/charts/stable/photoprism/SCALE/questions.yaml
+++ b/charts/stable/photoprism/SCALE/questions.yaml
@@ -1012,6 +1012,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1019,11 +1024,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/phpldapadmin/SCALE/questions.yaml
+++ b/charts/stable/phpldapadmin/SCALE/questions.yaml
@@ -871,6 +871,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -878,11 +883,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/piaware/SCALE/questions.yaml
+++ b/charts/stable/piaware/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/pihole/SCALE/questions.yaml
+++ b/charts/stable/pihole/SCALE/questions.yaml
@@ -1464,6 +1464,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/plex/SCALE/questions.yaml
+++ b/charts/stable/plex/SCALE/questions.yaml
@@ -1003,6 +1003,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1010,11 +1015,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/podgrab/SCALE/questions.yaml
+++ b/charts/stable/podgrab/SCALE/questions.yaml
@@ -984,6 +984,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -991,11 +996,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/postgresql/SCALE/questions.yaml
+++ b/charts/stable/postgresql/SCALE/questions.yaml
@@ -988,6 +988,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/pretend-youre-xyzzy/SCALE/questions.yaml
+++ b/charts/stable/pretend-youre-xyzzy/SCALE/questions.yaml
@@ -858,6 +858,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -865,11 +870,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/protonmail-bridge/SCALE/questions.yaml
+++ b/charts/stable/protonmail-bridge/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -994,11 +999,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/prowlarr/SCALE/questions.yaml
+++ b/charts/stable/prowlarr/SCALE/questions.yaml
@@ -977,6 +977,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -984,11 +989,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/pyload/SCALE/questions.yaml
+++ b/charts/stable/pyload/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -994,11 +999,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/qbittorrent/SCALE/questions.yaml
+++ b/charts/stable/qbittorrent/SCALE/questions.yaml
@@ -1121,6 +1121,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1128,11 +1133,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/radarr/SCALE/questions.yaml
+++ b/charts/stable/radarr/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/readarr/SCALE/questions.yaml
+++ b/charts/stable/readarr/SCALE/questions.yaml
@@ -976,6 +976,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -983,11 +988,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/reg/SCALE/questions.yaml
+++ b/charts/stable/reg/SCALE/questions.yaml
@@ -977,6 +977,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -984,11 +989,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/resilio-sync/SCALE/questions.yaml
+++ b/charts/stable/resilio-sync/SCALE/questions.yaml
@@ -1181,6 +1181,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"

--- a/charts/stable/sabnzbd/SCALE/questions.yaml
+++ b/charts/stable/sabnzbd/SCALE/questions.yaml
@@ -983,6 +983,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -990,11 +995,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/ser2sock/SCALE/questions.yaml
+++ b/charts/stable/ser2sock/SCALE/questions.yaml
@@ -995,6 +995,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1002,11 +1007,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/sonarr/SCALE/questions.yaml
+++ b/charts/stable/sonarr/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/stash/SCALE/questions.yaml
+++ b/charts/stable/stash/SCALE/questions.yaml
@@ -980,6 +980,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/syncthing/SCALE/questions.yaml
+++ b/charts/stable/syncthing/SCALE/questions.yaml
@@ -1233,6 +1233,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1240,11 +1245,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/tautulli/SCALE/questions.yaml
+++ b/charts/stable/tautulli/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/thelounge/SCALE/questions.yaml
+++ b/charts/stable/thelounge/SCALE/questions.yaml
@@ -982,6 +982,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: resources
     group: "Resources and Devices"

--- a/charts/stable/traefik/SCALE/questions.yaml
+++ b/charts/stable/traefik/SCALE/questions.yaml
@@ -1128,6 +1128,11 @@ questions:
           schema:
             type: boolean
             default: false
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"

--- a/charts/stable/transmission/SCALE/questions.yaml
+++ b/charts/stable/transmission/SCALE/questions.yaml
@@ -1462,6 +1462,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1469,11 +1474,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/truecommand/SCALE/questions.yaml
+++ b/charts/stable/truecommand/SCALE/questions.yaml
@@ -987,6 +987,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/tvheadend/SCALE/questions.yaml
+++ b/charts/stable/tvheadend/SCALE/questions.yaml
@@ -1082,6 +1082,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/unifi/SCALE/questions.yaml
+++ b/charts/stable/unifi/SCALE/questions.yaml
@@ -1416,6 +1416,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: false
   - variable: resources
     group: "Resources and Devices"
     label: ""

--- a/charts/stable/unpackerr/SCALE/questions.yaml
+++ b/charts/stable/unpackerr/SCALE/questions.yaml
@@ -849,6 +849,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -856,11 +861,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/vaultwarden/Chart.yaml
+++ b/charts/stable/vaultwarden/Chart.yaml
@@ -31,4 +31,4 @@ name: vaultwarden
 sources:
 - https://github.com/dani-garcia/vaultwarden
 type: application
-version: 7.0.0
+version: 7.0.1

--- a/charts/stable/vaultwarden/SCALE/questions.yaml
+++ b/charts/stable/vaultwarden/SCALE/questions.yaml
@@ -1368,6 +1368,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1375,11 +1380,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/xteve/SCALE/questions.yaml
+++ b/charts/stable/xteve/SCALE/questions.yaml
@@ -975,6 +975,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -982,11 +987,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/zwavejs2mqtt/SCALE/questions.yaml
+++ b/charts/stable/zwavejs2mqtt/SCALE/questions.yaml
@@ -1104,6 +1104,11 @@ questions:
           schema:
             type: boolean
             default: true
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1111,11 +1116,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"


### PR DESCRIPTION
**Description**
Some containers may use root sidecarts or root initcontainers.
Setting the runAsNonRoot on the podSecurityContext might cause issues for people where they should have none.

As we don't allow arbitrary sidecarts and initcontainers, it's pretty-much useless to force it on pod-level. Whereas the user idrunning the app on pod-level is actually usefull.

This also includes a fix in common to override it in the initcontainer as well, just to be extra sure.

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
