### PR TITLE
refactor: change image layout to enable renovate updates of sidecarts

### DIFF
--- a/charts/incubator/sogo/Chart.yaml
+++ b/charts/incubator/sogo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 5.2.0"
+appVersion: 5.2.0
 dependencies:
 - name: common
   repository: https://truecharts.org/
@@ -27,4 +27,4 @@ name: sogo
 sources:
 - https://www.sogo.nu/
 type: application
-version: 2.0.2
+version: 2.0.3

--- a/charts/incubator/sogo/SCALE/ix_values.yaml
+++ b/charts/incubator/sogo/SCALE/ix_values.yaml
@@ -8,9 +8,14 @@ image:
   pullPolicy: IfNotPresent
   tag: "v5.2.0"
 
+postgresqlImage:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  tag: 13.4-alpine
+
 initContainers:
   - name: init-postgresdb
-    image: postgres:13.1
+    image: "{{ .Values.postgresqlImage.repository}}:{{ .Values.postgresqlImage.tag }}"
     command:
       - "sh"
       - "-c"

--- a/charts/incubator/sogo/SCALE/ix_values.yaml
+++ b/charts/incubator/sogo/SCALE/ix_values.yaml
@@ -6,7 +6,7 @@
 image:
   repository: ghcr.io/truecharts/sogo
   pullPolicy: IfNotPresent
-  tag: "v5.2.0"
+  tag: v5.2.0
 
 postgresqlImage:
   repository: postgres

--- a/charts/incubator/sogo/values.yaml
+++ b/charts/incubator/sogo/values.yaml
@@ -2,7 +2,12 @@
 image:
   repository: ghcr.io/truecharts/sogo
   pullPolicy: IfNotPresent
-  tag: "v5.2.0"
+  tag: v5.2.0
+
+postgresqlImage:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  tag: 13.4-alpine
 
 # -- services
 service:
@@ -15,7 +20,7 @@ service:
 initContainers:
   # -- wait for database before starting sogo
   init-postgresdb:
-    image: postgres:13.1
+    image: "{{ .Values.postgresqlImage.repository }}:{{ .Values.postgresqlImage.tag }}"
     command:
       - "sh"
       - "-c"

--- a/charts/library/common/templates/addons/code-server/_container.tpl
+++ b/charts/library/common/templates/addons/code-server/_container.tpl
@@ -6,8 +6,8 @@ The code-server sidecar container to be inserted.
 {{- fail "At least 1 volumeMount is required for codeserver container" }}
 {{- end -}}
 name: codeserver
-image: "{{ .Values.addons.codeserver.image.repository }}:{{ .Values.addons.codeserver.image.tag }}"
-imagePullPolicy: {{ .Values.addons.codeserver.pullPolicy }}
+image: "{{ .Values.codeserverImage.repository }}:{{ .Values.codeserverImage.tag }}"
+imagePullPolicy: {{ .Values.codeserverImage.pullPolicy }}
 {{- with .Values.addons.codeserver.securityContext }}
 securityContext:
   {{- toYaml . | nindent 2 }}

--- a/charts/library/common/templates/addons/netshoot/_container.tpl
+++ b/charts/library/common/templates/addons/netshoot/_container.tpl
@@ -3,8 +3,8 @@ The netshoot sidecar container to be inserted.
 */}}
 {{- define "common.addon.netshoot.container" -}}
 name: netshoot
-image: "{{ .Values.addons.netshoot.image.repository }}:{{ .Values.addons.netshoot.image.tag }}"
-imagePullPolicy: {{ .Values.addons.netshoot.pullPolicy }}
+image: "{{ .Values.netshootImage.repository }}:{{ .Values.netshootImage.tag }}"
+imagePullPolicy: {{ .Values.netshootImage.pullPolicy }}
 {{- with .Values.addons.netshoot.securityContext }}
 securityContext:
   {{- toYaml . | nindent 2 }}

--- a/charts/library/common/templates/addons/promtail/_container.tpl
+++ b/charts/library/common/templates/addons/promtail/_container.tpl
@@ -6,8 +6,8 @@ The promtail sidecar container to be inserted.
 {{- fail "At least 1 volumeMount is required for the promtail container" }}
 {{- end -}}
 name: promtail
-image: "{{ .Values.addons.promtail.image.repository }}:{{ .Values.addons.promtail.image.tag }}"
-imagePullPolicy: {{ .Values.addons.promtail.pullPolicy }}
+image: "{{ .Values.promtailImage.repository }}:{{ .Values.promtailImage.tag }}"
+imagePullPolicy: {{ .Values.promtailImage.pullPolicy }}
 {{- with .Values.addons.promtail.securityContext }}
 securityContext:
   {{- toYaml . | nindent 2 }}

--- a/charts/library/common/templates/addons/vpn/openvpn/_container.tpl
+++ b/charts/library/common/templates/addons/vpn/openvpn/_container.tpl
@@ -3,8 +3,8 @@ The OpenVPN sidecar container to be inserted.
 */}}
 {{- define "common.addon.openvpn.container" -}}
 name: openvpn
-image: "{{ .Values.addons.vpn.openvpn.image.repository }}:{{ .Values.addons.vpn.openvpn.image.tag }}"
-imagePullPolicy: {{ .Values.addons.vpn.openvpn.pullPolicy }}
+image: "{{ .Values.openvpnImage.repository }}:{{ .Values.openvpnImage.tag }}"
+imagePullPolicy: {{ .Values.openvpnImage.pullPolicy }}
 {{- with .Values.addons.vpn.securityContext }}
 securityContext:
   {{- toYaml . | nindent 2 }}

--- a/charts/library/common/templates/addons/vpn/wireguard/_container.tpl
+++ b/charts/library/common/templates/addons/vpn/wireguard/_container.tpl
@@ -3,8 +3,8 @@ The Wireguard sidecar container to be inserted.
 */}}
 {{- define "common.addon.wireguard.container" -}}
 name: wireguard
-image: "{{ .Values.addons.vpn.wireguard.image.repository }}:{{ .Values.addons.vpn.wireguard.image.tag }}"
-imagePullPolicy: {{ .Values.addons.vpn.wireguard.pullPolicy }}
+image: "{{ .Values.wireguardImage.repository }}:{{ .Values.wireguardImage.tag }}"
+imagePullPolicy: {{ .Values.wireguardImage.pullPolicy }}
 {{- with .Values.addons.vpn.securityContext }}
 securityContext:
   {{- toYaml . | nindent 2 }}

--- a/charts/library/common/templates/lib/controller/_autopermissions.yaml
+++ b/charts/library/common/templates/lib/controller/_autopermissions.yaml
@@ -17,7 +17,7 @@ before chart installation.
   {{- end -}}
 {{- end }}
 - name: autopermissions
-  image: alpine:3.3
+  image: {{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}
   securityContext:
     allowPrivilegeEscalation: false
     runAsUser: 0

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -1,3 +1,57 @@
+# -- OpenVPN specific configuration
+# @default -- See below
+openvpnImage:
+  # -- Specify the openvpn client image
+  repository: dperson/openvpn-client
+  # -- Specify the openvpn client image tag
+  tag: latest
+  # -- Specify the openvpn client image pull policy
+  pullPolicy: IfNotPresent
+
+
+# -- WireGuard specific configuration
+# @default -- See below
+wireguardImage:
+  # -- Specify the WireGuard image
+  repository: ghcr.io/k8s-at-home/wireguard
+  # -- Specify the WireGuard image tag
+  tag: v1.0.20210424
+  # -- Specify the WireGuard image pull policy
+  pullPolicy: IfNotPresent
+
+promtailImage:
+  # -- Specify the promtail image
+  repository: grafana/promtail
+  # -- Specify the promtail image tag
+  tag: 2.2.0
+  # -- Specify the promtail image pull policy
+  pullPolicy: IfNotPresent
+
+
+netshootImage:
+  # -- Specify the netshoot image
+  repository: nicolaka/netshoot
+  # -- Specify the netshoot image tag
+  tag: latest
+  # -- Specify the netshoot image pull policy
+  pullPolicy: Always
+
+codeserverImage:
+  # -- Specify the code-server image
+  repository: codercom/code-server
+  # -- Specify the code-server image tag
+  tag: 3.9.2
+  # -- Specify the code-server image pull policy
+  pullPolicy: IfNotPresent
+
+alpineImage:
+  # -- Specify the code-server image
+  repository: alpine
+  # -- Specify the code-server image tag
+  tag: "3.3"
+  # -- Specify the code-server image pull policy
+  pullPolicy: IfNotPresent
+
 global:
   # -- Set an override for the prefix of the fullname
   nameOverride:
@@ -641,30 +695,14 @@ addons:
     # -- OpenVPN specific configuration
     # @default -- See below
     openvpn:
-      image:
-        # -- Specify the openvpn client image
-        repository: dperson/openvpn-client
-        # -- Specify the openvpn client image tag
-        tag: latest
-        # -- Specify the openvpn client image pull policy
-        pullPolicy: IfNotPresent
-
       # -- Credentials to connect to the VPN Service (used with -a)
       auth:  # "user;password"
       # -- Optionally specify an existing secret that contains the credentials.
       # Credentials should be stored under the `VPN_AUTH` key
       authSecret:  # my-vpn-secret
-
     # -- WireGuard specific configuration
     # @default -- See below
-    wireguard:
-      image:
-        # -- Specify the WireGuard image
-        repository: ghcr.io/k8s-at-home/wireguard
-        # -- Specify the WireGuard image tag
-        tag: v1.0.20210424
-        # -- Specify the WireGuard image pull policy
-        pullPolicy: IfNotPresent
+    wireguard: {}
 
     # -- Set the VPN container securityContext
     # @default -- See values.yaml
@@ -690,7 +728,6 @@ addons:
       # See Kubernetes documentation for options.
       hostPathType: "File"
 
-
     # -- Provide custom up/down scripts that can be used by the vpn configuration.
     # @default -- See values.yaml
     scripts:
@@ -709,18 +746,9 @@ addons:
     # -- Enable running a code-server container in the pod
     enabled: false
 
-    image:
-      # -- Specify the code-server image
-      repository: codercom/code-server
-      # -- Specify the code-server image tag
-      tag: 3.9.2
-      # -- Specify the code-server image pull policy
-      pullPolicy: IfNotPresent
-
     # -- Set any environment variables for code-server here
     env: {}
       # TZ: UTC
-
     # -- Set codeserver command line arguments.
     # Consider setting --user-data-dir to a persistent location to preserve code-server setting changes
     args:
@@ -794,24 +822,12 @@ addons:
   promtail:
     # -- Enable running a promtail container in the pod
     enabled: false
-
-    image:
-      # -- Specify the promtail image
-      repository: grafana/promtail
-      # -- Specify the promtail image tag
-      tag: 2.2.0
-      # -- Specify the promtail image pull policy
-      pullPolicy: IfNotPresent
-
     # -- Set any environment variables for promtail here
     env: {}
-
     # -- Set promtail command line arguments
     args: []
-
     # -- The URL to Loki
     loki: ""
-
     # -- The paths to logs on the volume
     logs: []
     # - name: log
@@ -832,14 +848,6 @@ addons:
   netshoot:
     # -- Enable running a netshoot container in the pod
     enabled: false
-
-    image:
-      # -- Specify the netshoot image
-      repository: nicolaka/netshoot
-      # -- Specify the netshoot image tag
-      tag: latest
-      # -- Specify the netshoot image pull policy
-      pullPolicy: Always
 
     # -- Set any environment variables for netshoot here
     env: {}

--- a/charts/stable/authelia/SCALE/ix_values.yaml
+++ b/charts/stable/authelia/SCALE/ix_values.yaml
@@ -9,6 +9,12 @@ image:
   pullPolicy: IfNotPresent
   tag: "4.30.4"
 
+postgresqlImage:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  tag: 13.4-alpine
+
+
 enableServiceLinks: false
 
 command: ["authelia"]
@@ -17,7 +23,7 @@ args: ["--config=/configuration.yaml"]
 
 initContainers:
   init-postgresdb:
-    image: postgres:13.1
+    image: "{{ .Values.postgresqlImage.repository}}:{{ .Values.postgresqlImage.tag }}"
     command:
       - "sh"
       - "-c"

--- a/charts/stable/authelia/values.yaml
+++ b/charts/stable/authelia/values.yaml
@@ -5,6 +5,12 @@ image:
   pullPolicy: IfNotPresent
   tag: "4.30.4"
 
+
+postgresqlImage:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  tag: 13.4-alpine
+
 command: ["authelia"]
 args: ["--config=/configuration.yaml"]
 
@@ -21,7 +27,7 @@ service:
 
 initContainers:
   init-postgresdb:
-    image: postgres:13.1
+    image: "{{ .Values.postgresqlImage.repository}}:{{ .Values.postgresqlImage.tag }}"
     command:
       - "sh"
       - "-c"

--- a/charts/stable/fireflyiii/SCALE/ix_values.yaml
+++ b/charts/stable/fireflyiii/SCALE/ix_values.yaml
@@ -9,9 +9,15 @@ image:
   pullPolicy: IfNotPresent
   tag: version-5.5.12
 
+
+postgresqlImage:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  tag: 13.4-alpine
+
 initContainers:
   init-postgresdb:
-    image: postgres:13.1
+    image: "{{ .Values.postgresqlImage.repository}}:{{ .Values.postgresqlImage.tag }}"
     command:
       - "sh"
       - "-c"

--- a/charts/stable/fireflyiii/values.yaml
+++ b/charts/stable/fireflyiii/values.yaml
@@ -5,6 +5,12 @@ image:
   pullPolicy: IfNotPresent
   tag: version-5.5.12
 
+
+postgresqlImage:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  tag: 13.4-alpine
+
 strategy:
   type: Recreate
 
@@ -22,7 +28,7 @@ service:
 
 initContainers:
   init-postgresdb:
-    image: postgres:13.1
+    image: "{{ .Values.postgresqlImage.repository}}:{{ .Values.postgresqlImage.tag }}"
     command:
       - "sh"
       - "-c"

--- a/charts/stable/nextcloud/SCALE/ix_values.yaml
+++ b/charts/stable/nextcloud/SCALE/ix_values.yaml
@@ -9,6 +9,11 @@ image:
   pullPolicy: IfNotPresent
   tag: 22.1.1
 
+postgresqlImage:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  tag: 13.4-alpine
+
 strategy:
   type: Recreate
 
@@ -43,7 +48,7 @@ envValueFrom:
 
 initContainers:
   init-postgresdb:
-    image: postgres:13.1
+    image: "{{ .Values.postgresqlImage.repository}}:{{ .Values.postgresqlImage.tag }}"
     command:
       - "sh"
       - "-c"
@@ -55,7 +60,6 @@ initContainers:
           secretKeyRef:
             name: dbcreds
             key: plainhost
-
 
 # -- Probe configuration
 # -- [[ref]](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -5,6 +5,11 @@ image:
   pullPolicy: IfNotPresent
   tag: 22.1.1
 
+postgresqlImage:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  tag: "13.1"
+
 strategy:
   type: Recreate
 
@@ -69,7 +74,7 @@ persistence:
 
 initContainers:
   init-postgresdb:
-    image: postgres:13.1
+    image: "{{ .Values.postgresqlImage.repository}}:{{ .Values.postgresqlImage.tag }}"
     command:
       - "sh"
       - "-c"

--- a/charts/stable/vaultwarden/SCALE/ix_values.yaml
+++ b/charts/stable/vaultwarden/SCALE/ix_values.yaml
@@ -9,6 +9,12 @@ image:
   pullPolicy: IfNotPresent
   tag: 1.22.2
 
+postgresqlImage:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  tag: 13.4-alpine
+
+
 envTpl:
   DOMAIN: "https://{{ if .Values.ingress }}{{ if .Values.ingress.main.enabled }}{{ ( index .Values.ingress.main.hosts 0 ).host }}{{ else }}placeholder.com{{ end }}{{ else }}placeholder.com{{ end }}"
 
@@ -20,7 +26,7 @@ envFrom:
 
 initContainers:
   init-postgresdb:
-    image: postgres:13.1
+    image: "{{ .Values.postgresqlImage.repository }}:{{ .Values.postgresqlImage.tag }}"
     command:
       - "sh"
       - "-c"

--- a/charts/stable/vaultwarden/values.yaml
+++ b/charts/stable/vaultwarden/values.yaml
@@ -5,6 +5,12 @@ image:
   pullPolicy: IfNotPresent
   tag: 1.22.2
 
+postgresqlImage:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  tag: 13.4-alpine
+
+
 strategy:
   type: Recreate
 
@@ -91,7 +97,7 @@ ingress:
 
 initContainers:
   init-postgresdb:
-    image: postgres:13.1
+    image: "{{ .Values.postgresqlImage.repository }}:{{ .Values.postgresqlImage.tag }}"
     command:
       - "sh"
       - "-c"

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -123,7 +123,7 @@ sync_tag() {
     local train="$3"
     local chartversion="$4"
     echo "Attempting to sync primary tag with appversion for: ${chartname}"
-    local tag="$(cat ${chart}/values.yaml | grep "^  tag: " | awk -F" " '{ print $2 }')"
+    local tag="$(cat ${chart}/values.yaml | grep '^  tag: ' | awk -F" " '{ print $2 }')"
     tag="${tag:-auto}"
     tag="${tag#*release-}"
     tag="${tag#*version-}"

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -123,7 +123,7 @@ sync_tag() {
     local train="$3"
     local chartversion="$4"
     echo "Attempting to sync primary tag with appversion for: ${chartname}"
-    local tag="$(cat ${chart}/values.yaml | grep '^  tag: ' | awk -F" " '{ print $2 }')"
+    local tag="$(cat ${chart}/values.yaml | grep '^  tag: ' | awk -F" " '{ print $2 }' | head -1)"
     tag="${tag:-auto}"
     tag="${tag#*release-}"
     tag="${tag#*version-}"


### PR DESCRIPTION
**Description**
Currently the images for addons, initcontainers and sidecarts cannot be updated by renovate.
This patch moves those images to a structure that is compatible with renovate.

**Type of change**

- [x] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
