### PR TITLE
fix: make sure podSecurityContext is included in SCALE and Helm installs

### DIFF
--- a/charts/incubator/custom-app/values.yaml
+++ b/charts/incubator/custom-app/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v0.18.686
 
-strategy:
-  type: Recreate
+
 
 
 service:

--- a/charts/incubator/custom-app/values.yaml
+++ b/charts/incubator/custom-app/values.yaml
@@ -5,8 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v0.18.686
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
-
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/appdaemon/values.yaml
+++ b/charts/stable/appdaemon/values.yaml
@@ -3,14 +3,18 @@ image:
   pullPolicy: IfNotPresent
   tag: "v4.0.8"
 
-
-
-# Configure the Security Context for the Pod
-podSecurityContext:
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
   runAsNonRoot: true
+
+podSecurityContext:
   runAsUser: 568
   runAsGroup: 568
   fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 env:
   TZ: "America/Chicago"

--- a/charts/stable/appdaemon/values.yaml
+++ b/charts/stable/appdaemon/values.yaml
@@ -3,8 +3,7 @@ image:
   pullPolicy: IfNotPresent
   tag: "v4.0.8"
 
-strategy:
-  type: Recreate
+
 
 # Configure the Security Context for the Pod
 podSecurityContext:

--- a/charts/stable/authelia/values.yaml
+++ b/charts/stable/authelia/values.yaml
@@ -26,8 +26,6 @@ postgresqlImage:
 command: ["authelia"]
 args: ["--config=/configuration.yaml"]
 
-
-
 enableServiceLinks: false
 
 service:

--- a/charts/stable/authelia/values.yaml
+++ b/charts/stable/authelia/values.yaml
@@ -14,8 +14,7 @@ postgresqlImage:
 command: ["authelia"]
 args: ["--config=/configuration.yaml"]
 
-strategy:
-  type: Recreate
+
 
 enableServiceLinks: false
 

--- a/charts/stable/authelia/values.yaml
+++ b/charts/stable/authelia/values.yaml
@@ -5,6 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: "4.30.4"
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 postgresqlImage:
   repository: postgres
@@ -79,18 +91,6 @@ redis:
     replicaCount: 0
     persistence:
       enabled: false
-
-
-podSecurityContext:
-  runAsUser: 568
-  runAsGroup: 568
-  fsGroup: 568
-
-securityContext:
-  readOnlyRootFilesystem: true
-  allowPrivilegeEscalation: false
-  privileged: false
-
 
 resources:
   limits: {}

--- a/charts/stable/bazarr/values.yaml
+++ b/charts/stable/bazarr/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v0.9.8
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/bazarr/values.yaml
+++ b/charts/stable/bazarr/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v0.9.8
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/calibre-web/values.yaml
+++ b/charts/stable/calibre-web/values.yaml
@@ -5,8 +5,6 @@ image:
   pullPolicy: IfNotPresent
   tag: version-0.6.12
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/calibre-web/values.yaml
+++ b/charts/stable/calibre-web/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: version-0.6.12
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/collabora-online/values.yaml
+++ b/charts/stable/collabora-online/values.yaml
@@ -3,8 +3,6 @@ image:
   tag: 6.4.10.10
   pullPolicy: IfNotPresent
 
-
-
 service:
   main:
     type: NodePort

--- a/charts/stable/collabora-online/values.yaml
+++ b/charts/stable/collabora-online/values.yaml
@@ -3,8 +3,7 @@ image:
   tag: 6.4.10.10
   pullPolicy: IfNotPresent
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/deepstack-cpu/values.yaml
+++ b/charts/stable/deepstack-cpu/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: cpu-2021.02.1
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/deepstack-cpu/values.yaml
+++ b/charts/stable/deepstack-cpu/values.yaml
@@ -5,8 +5,6 @@ image:
   pullPolicy: IfNotPresent
   tag: cpu-2021.02.1
 
-
-
 service:
   main:
     enabled: true

--- a/charts/stable/deluge/values.yaml
+++ b/charts/stable/deluge/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: version-2.0.3-2201906121747ubuntu18.04.1
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/deluge/values.yaml
+++ b/charts/stable/deluge/values.yaml
@@ -5,8 +5,6 @@ image:
   pullPolicy: IfNotPresent
   tag: version-2.0.3-2201906121747ubuntu18.04.1
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/emby/values.yaml
+++ b/charts/stable/emby/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v4.6.4.0
 
-strategy:
-  type: Recreate
+
 
 # 44=video 107=render
 podSecurityContext:

--- a/charts/stable/emby/values.yaml
+++ b/charts/stable/emby/values.yaml
@@ -5,15 +5,19 @@ image:
   pullPolicy: IfNotPresent
   tag: v4.6.4.0
 
-
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
 # 44=video 107=render
 podSecurityContext:
-  runAsNonRoot: true
   runAsUser: 568
   runAsGroup: 568
   fsGroup: 568
   supplementalGroups: [44, 107]
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/esphome/values.yaml
+++ b/charts/stable/esphome/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 2021.8.2
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/esphome/values.yaml
+++ b/charts/stable/esphome/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: 2021.8.2
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/fireflyiii/values.yaml
+++ b/charts/stable/fireflyiii/values.yaml
@@ -11,8 +11,7 @@ postgresqlImage:
   pullPolicy: IfNotPresent
   tag: 13.4-alpine
 
-strategy:
-  type: Recreate
+
 
 podSecurityContext:
   runAsNonRoot: false

--- a/charts/stable/fireflyiii/values.yaml
+++ b/charts/stable/fireflyiii/values.yaml
@@ -11,13 +11,18 @@ postgresqlImage:
   pullPolicy: IfNotPresent
   tag: 13.4-alpine
 
-
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: false
 
 podSecurityContext:
-  runAsNonRoot: false
   runAsUser: 0
   runAsGroup: 0
   fsGroup: 0
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/flaresolverr/values.yaml
+++ b/charts/stable/flaresolverr/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image tag
   tag: v1.2.9
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See more environment variables in the [flaresolverr documentation](https://github.com/FlareSolverr/FlareSolverr#environment-variables).
 # @default -- See below
 env:

--- a/charts/stable/flood/values.yaml
+++ b/charts/stable/flood/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image tag
   tag: 4.6.1
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See more environment variables in the [flood documentation] (https://github.com/jesec/flood/blob/v4.6.0/config.ts)
 # Note: The environmental variables are not case sensitive (e.g. FLOOD_OPTION_port=FLOOD_OPTION_PORT).
 # @default -- See below

--- a/charts/stable/focalboard/values.yaml
+++ b/charts/stable/focalboard/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image tag
   tag: 0.8.0
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See more environment variables in the [image entrypoint script](https://github.com/FlipEnergy/container-images/blob/main/focalboard/entrypoint.sh)
 # @default -- See below
 env: {}

--- a/charts/stable/freshrss/values.yaml
+++ b/charts/stable/freshrss/values.yaml
@@ -5,8 +5,6 @@ image:
   pullPolicy: IfNotPresent
   tag: version-1.18.1
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/freshrss/values.yaml
+++ b/charts/stable/freshrss/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: version-1.18.1
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/gaps/values.yaml
+++ b/charts/stable/gaps/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v0.8.8
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/gaps/values.yaml
+++ b/charts/stable/gaps/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v0.8.8
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/gonic/SCALE/questions.yaml
+++ b/charts/stable/gonic/SCALE/questions.yaml
@@ -979,7 +979,7 @@ questions:
           label: "runAsNonRoot"
           schema:
             type: boolean
-            default: true
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -992,13 +992,13 @@ questions:
           description: "The UserID of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: runAsGroup
           label: "runAsGroup"
           description: The groupID this App of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: fsGroup
           label: "fsGroup"
           description: "The group that should own ALL storage."

--- a/charts/stable/gonic/SCALE/questions.yaml
+++ b/charts/stable/gonic/SCALE/questions.yaml
@@ -1004,7 +1004,7 @@ questions:
           description: "The group that should own ALL storage."
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: supplementalGroups
           label: "supplemental Groups"
           schema:

--- a/charts/stable/gonic/values.yaml
+++ b/charts/stable/gonic/values.yaml
@@ -22,7 +22,7 @@ securityContext:
 podSecurityContext:
   runAsUser: 0
   runAsGroup: 0
-  fsGroup: 568
+  fsGroup: 0
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"
 

--- a/charts/stable/gonic/values.yaml
+++ b/charts/stable/gonic/values.yaml
@@ -17,11 +17,11 @@ securityContext:
   privileged: false
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: true
-  runAsNonRoot: true
+  runAsNonRoot: false
 
 podSecurityContext:
-  runAsUser: 568
-  runAsGroup: 568
+  runAsUser: 0
+  runAsGroup: 0
   fsGroup: 568
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"

--- a/charts/stable/gonic/values.yaml
+++ b/charts/stable/gonic/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image tag
   tag: v0.13.1
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See more environment variables in the [gonic documentation](https://github.com/sentriz/gonic#configuration-options)
 # @default -- See below
 env:

--- a/charts/stable/grocy/values.yaml
+++ b/charts/stable/grocy/values.yaml
@@ -5,8 +5,6 @@ image:
   tag: version-v3.1.1
   pullPolicy: IfNotPresent
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/grocy/values.yaml
+++ b/charts/stable/grocy/values.yaml
@@ -5,8 +5,7 @@ image:
   tag: version-v3.1.1
   pullPolicy: IfNotPresent
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/handbrake/values.yaml
+++ b/charts/stable/handbrake/values.yaml
@@ -3,8 +3,6 @@ image:
   tag: v1.24.1
   pullPolicy: IfNotPresent
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/handbrake/values.yaml
+++ b/charts/stable/handbrake/values.yaml
@@ -3,8 +3,7 @@ image:
   tag: v1.24.1
   pullPolicy: IfNotPresent
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/haste-server/values.yaml
+++ b/charts/stable/haste-server/values.yaml
@@ -13,8 +13,7 @@ image:
   # -- image tag
   tag: latest
 
-strategy:
-  type: Recreate
+
 
 podSecurityContext:
   runAsNonRoot: true

--- a/charts/stable/haste-server/values.yaml
+++ b/charts/stable/haste-server/values.yaml
@@ -13,12 +13,18 @@ image:
   # -- image tag
   tag: latest
 
-
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
 podSecurityContext:
-  runAsNonRoot: true
   runAsUser: 568
   runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 # -- environment variables. See [image docs](https://github.com/seejohnrun/haste-server) for more details.
 # @default -- See below

--- a/charts/stable/heimdall/values.yaml
+++ b/charts/stable/heimdall/values.yaml
@@ -5,8 +5,7 @@ image:
   tag: version-2.2.2
   pullPolicy: IfNotPresent
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/heimdall/values.yaml
+++ b/charts/stable/heimdall/values.yaml
@@ -5,8 +5,6 @@ image:
   tag: version-2.2.2
   pullPolicy: IfNotPresent
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/home-assistant/values.yaml
+++ b/charts/stable/home-assistant/values.yaml
@@ -5,8 +5,6 @@ image:
   pullPolicy: IfNotPresent
   tag: 2021.9.4
 
-
-
 env: {}
     # TZ:
 

--- a/charts/stable/home-assistant/values.yaml
+++ b/charts/stable/home-assistant/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 2021.9.4
 
-strategy:
-  type: Recreate
+
 
 env: {}
     # TZ:

--- a/charts/stable/hyperion-ng/SCALE/questions.yaml
+++ b/charts/stable/hyperion-ng/SCALE/questions.yaml
@@ -1282,7 +1282,7 @@ questions:
           label: "runAsNonRoot"
           schema:
             type: boolean
-            default: true
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1295,13 +1295,13 @@ questions:
           description: "The UserID of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: runAsGroup
           label: "runAsGroup"
           description: The groupID this App of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: fsGroup
           label: "fsGroup"
           description: "The group that should own ALL storage."

--- a/charts/stable/hyperion-ng/SCALE/questions.yaml
+++ b/charts/stable/hyperion-ng/SCALE/questions.yaml
@@ -1307,7 +1307,7 @@ questions:
           description: "The group that should own ALL storage."
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: supplementalGroups
           label: "supplemental Groups"
           schema:

--- a/charts/stable/hyperion-ng/values.yaml
+++ b/charts/stable/hyperion-ng/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See [image docs](https://docs.linuxserver.io/images/docker-airsonic#environment-variables-e) for more details.
 # @default -- See below
 env:

--- a/charts/stable/hyperion-ng/values.yaml
+++ b/charts/stable/hyperion-ng/values.yaml
@@ -22,7 +22,7 @@ securityContext:
 podSecurityContext:
   runAsUser: 0
   runAsGroup: 0
-  fsGroup: 568
+  fsGroup: 0
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"
 

--- a/charts/stable/hyperion-ng/values.yaml
+++ b/charts/stable/hyperion-ng/values.yaml
@@ -17,11 +17,11 @@ securityContext:
   privileged: false
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: true
-  runAsNonRoot: true
+  runAsNonRoot: false
 
 podSecurityContext:
-  runAsUser: 568
-  runAsGroup: 568
+  runAsUser: 0
+  runAsGroup: 0
   fsGroup: 568
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"

--- a/charts/stable/jackett/values.yaml
+++ b/charts/stable/jackett/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v0.18.686
 
-strategy:
-  type: Recreate
+
 
 
 service:

--- a/charts/stable/jackett/values.yaml
+++ b/charts/stable/jackett/values.yaml
@@ -5,8 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v0.18.686
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
-
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/jdownloader2/values.yaml
+++ b/charts/stable/jdownloader2/values.yaml
@@ -5,8 +5,6 @@ image:
   pullPolicy: IfNotPresent
   tag: v1.7.1
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/jdownloader2/values.yaml
+++ b/charts/stable/jdownloader2/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v1.7.1
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/jellyfin/values.yaml
+++ b/charts/stable/jellyfin/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 10.7.7
 
-strategy:
-  type: Recreate
+
 
 # 44=video 107=render
 podSecurityContext:

--- a/charts/stable/jellyfin/values.yaml
+++ b/charts/stable/jellyfin/values.yaml
@@ -5,15 +5,19 @@ image:
   pullPolicy: IfNotPresent
   tag: 10.7.7
 
-
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
 # 44=video 107=render
 podSecurityContext:
-  runAsNonRoot: true
   runAsUser: 568
   runAsGroup: 568
   fsGroup: 568
   supplementalGroups: [44, 107]
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/kms/values.yaml
+++ b/charts/stable/kms/values.yaml
@@ -5,8 +5,6 @@ image:
   pullPolicy: IfNotPresent
   tag: minimal
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/kms/values.yaml
+++ b/charts/stable/kms/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: minimal
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/komga/values.yaml
+++ b/charts/stable/komga/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See more environment variables in the [komga documentation](https://komga.org/installation/configuration.html#optional-configuration).
 # @default -- See below
 env: {}

--- a/charts/stable/lazylibrarian/values.yaml
+++ b/charts/stable/lazylibrarian/values.yaml
@@ -5,8 +5,6 @@ image:
   pullPolicy: IfNotPresent
   tag: latest
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/lazylibrarian/values.yaml
+++ b/charts/stable/lazylibrarian/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: latest
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/lidarr/values.yaml
+++ b/charts/stable/lidarr/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v1.0.0.2255
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/lidarr/values.yaml
+++ b/charts/stable/lidarr/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v1.0.0.2255
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/littlelink/values.yaml
+++ b/charts/stable/littlelink/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: latest
 
-strategy:
-  type: Recreate
+
 
 
 service:

--- a/charts/stable/littlelink/values.yaml
+++ b/charts/stable/littlelink/values.yaml
@@ -6,8 +6,6 @@ image:
   tag: latest
 
 
-
-
 service:
   main:
     enabled: true

--- a/charts/stable/lychee/values.yaml
+++ b/charts/stable/lychee/values.yaml
@@ -5,8 +5,6 @@ image:
   pullPolicy: IfNotPresent
   tag: v4.3.4
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/lychee/values.yaml
+++ b/charts/stable/lychee/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v4.3.4
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -8,6 +8,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- Configures service settings for the chart. Normally this does not need to be modified.
 # @default -- See values.yaml
 service:

--- a/charts/stable/mylar/SCALE/questions.yaml
+++ b/charts/stable/mylar/SCALE/questions.yaml
@@ -1016,7 +1016,7 @@ questions:
           description: "The group that should own ALL storage."
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: supplementalGroups
           label: "supplemental Groups"
           schema:

--- a/charts/stable/mylar/SCALE/questions.yaml
+++ b/charts/stable/mylar/SCALE/questions.yaml
@@ -991,7 +991,7 @@ questions:
           label: "runAsNonRoot"
           schema:
             type: boolean
-            default: true
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1004,13 +1004,13 @@ questions:
           description: "The UserID of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: runAsGroup
           label: "runAsGroup"
           description: The groupID this App of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: fsGroup
           label: "fsGroup"
           description: "The group that should own ALL storage."

--- a/charts/stable/mylar/values.yaml
+++ b/charts/stable/mylar/values.yaml
@@ -22,7 +22,7 @@ securityContext:
 podSecurityContext:
   runAsUser: 0
   runAsGroup: 0
-  fsGroup: 568
+  fsGroup: 0
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"
 

--- a/charts/stable/mylar/values.yaml
+++ b/charts/stable/mylar/values.yaml
@@ -17,11 +17,11 @@ securityContext:
   privileged: false
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: true
-  runAsNonRoot: true
+  runAsNonRoot: false
 
 podSecurityContext:
-  runAsUser: 568
-  runAsGroup: 568
+  runAsUser: 0
+  runAsGroup: 0
   fsGroup: 568
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"

--- a/charts/stable/mylar/values.yaml
+++ b/charts/stable/mylar/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See [image docs](https://docs.linuxserver.io/images/docker-mylar3#environment-variables-e) for more details.
 # @default -- See below
 env:

--- a/charts/stable/navidrome/values.yaml
+++ b/charts/stable/navidrome/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 0.45.1
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/navidrome/values.yaml
+++ b/charts/stable/navidrome/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: 0.45.1
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -23,8 +23,6 @@ postgresqlImage:
   pullPolicy: IfNotPresent
   tag: "13.1"
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -10,8 +10,7 @@ postgresqlImage:
   pullPolicy: IfNotPresent
   tag: "13.1"
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -5,12 +5,6 @@ image:
   pullPolicy: IfNotPresent
   tag: 22.1.1
 
-securityContext:
-  privileged: false
-  readOnlyRootFilesystem: false
-  allowPrivilegeEscalation: true
-  runAsNonRoot: false
-
 podSecurityContext:
   runAsUser: 0
   runAsGroup: 0

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -5,6 +5,19 @@ image:
   pullPolicy: IfNotPresent
   tag: 22.1.1
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: false
+
+podSecurityContext:
+  runAsUser: 0
+  runAsGroup: 0
+  fsGroup: 33
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 postgresqlImage:
   repository: postgres
   pullPolicy: IfNotPresent
@@ -85,10 +98,6 @@ initContainers:
           secretKeyRef:
             name: dbcreds
             key: plainhost
-
-
-podSecurityContext:
-  fsGroup: 33
 
 # -- Probe configuration
 # -- [[ref]](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)

--- a/charts/stable/node-red/values.yaml
+++ b/charts/stable/node-red/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: 2.0.6
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 # See more environment varaibles in the node-red documentation
 # https://nodered.org/docs/getting-started/docker

--- a/charts/stable/node-red/values.yaml
+++ b/charts/stable/node-red/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 2.0.6
 
-strategy:
-  type: Recreate
+
 
 # See more environment varaibles in the node-red documentation
 # https://nodered.org/docs/getting-started/docker

--- a/charts/stable/nullserv/SCALE/questions.yaml
+++ b/charts/stable/nullserv/SCALE/questions.yaml
@@ -1082,7 +1082,7 @@ questions:
           label: "runAsNonRoot"
           schema:
             type: boolean
-            default: true
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1095,13 +1095,13 @@ questions:
           description: "The UserID of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: runAsGroup
           label: "runAsGroup"
           description: The groupID this App of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: fsGroup
           label: "fsGroup"
           description: "The group that should own ALL storage."

--- a/charts/stable/nullserv/SCALE/questions.yaml
+++ b/charts/stable/nullserv/SCALE/questions.yaml
@@ -1107,7 +1107,7 @@ questions:
           description: "The group that should own ALL storage."
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: supplementalGroups
           label: "supplemental Groups"
           schema:

--- a/charts/stable/nullserv/values.yaml
+++ b/charts/stable/nullserv/values.yaml
@@ -26,7 +26,7 @@ securityContext:
 podSecurityContext:
   runAsUser: 0
   runAsGroup: 0
-  fsGroup: 568
+  fsGroup: 0
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"
 

--- a/charts/stable/nullserv/values.yaml
+++ b/charts/stable/nullserv/values.yaml
@@ -17,6 +17,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See more environment variables in the [nullserv documentation](https://github.com/bmrzycki/nullserv/blob/master/README.md).
 # @default -- See below
 env:

--- a/charts/stable/nullserv/values.yaml
+++ b/charts/stable/nullserv/values.yaml
@@ -21,11 +21,11 @@ securityContext:
   privileged: false
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: true
-  runAsNonRoot: true
+  runAsNonRoot: false
 
 podSecurityContext:
-  runAsUser: 568
-  runAsGroup: 568
+  runAsUser: 0
+  runAsGroup: 0
   fsGroup: 568
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"

--- a/charts/stable/nzbget/values.yaml
+++ b/charts/stable/nzbget/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v21.1
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/nzbget/values.yaml
+++ b/charts/stable/nzbget/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v21.1
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/nzbhydra/values.yaml
+++ b/charts/stable/nzbhydra/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v3.15.2
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/nzbhydra/values.yaml
+++ b/charts/stable/nzbhydra/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v3.15.2
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/omada-controller/SCALE/questions.yaml
+++ b/charts/stable/omada-controller/SCALE/questions.yaml
@@ -979,7 +979,7 @@ questions:
           label: "runAsNonRoot"
           schema:
             type: boolean
-            default: true
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -992,13 +992,13 @@ questions:
           description: "The UserID of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: runAsGroup
           label: "runAsGroup"
           description: The groupID this App of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: fsGroup
           label: "fsGroup"
           description: "The group that should own ALL storage."

--- a/charts/stable/omada-controller/SCALE/questions.yaml
+++ b/charts/stable/omada-controller/SCALE/questions.yaml
@@ -1004,7 +1004,7 @@ questions:
           description: "The group that should own ALL storage."
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: supplementalGroups
           label: "supplemental Groups"
           schema:

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -22,7 +22,7 @@ securityContext:
 podSecurityContext:
   runAsUser: 0
   runAsGroup: 0
-  fsGroup: 568
+  fsGroup: 0
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"
 

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -17,11 +17,11 @@ securityContext:
   privileged: false
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: true
-  runAsNonRoot: true
+  runAsNonRoot: false
 
 podSecurityContext:
-  runAsUser: 568
-  runAsGroup: 568
+  runAsUser: 0
+  runAsGroup: 0
   fsGroup: 568
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See [image docs](https://github.com/mbentley/docker-omada-controller) for more details.
 # @default -- See below
 env:

--- a/charts/stable/ombi/values.yaml
+++ b/charts/stable/ombi/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v4.0.1475
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/ombi/values.yaml
+++ b/charts/stable/ombi/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v4.0.1475
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/organizr/values.yaml
+++ b/charts/stable/organizr/values.yaml
@@ -5,8 +5,6 @@ image:
   pullPolicy: Always
   tag: latest
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/organizr/values.yaml
+++ b/charts/stable/organizr/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: Always
   tag: latest
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/overseerr/values.yaml
+++ b/charts/stable/overseerr/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables.
 # @default -- See below
 env:

--- a/charts/stable/owncloud-ocis/values.yaml
+++ b/charts/stable/owncloud-ocis/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See more environment variables in the [owncloud-ocis documentation](https://owncloud.dev/ocis/configuration/#environment-variables).
 # @default -- See below
 env:

--- a/charts/stable/pgadmin/values.yaml
+++ b/charts/stable/pgadmin/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: "5.6"
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: false
 
+podSecurityContext:
+  runAsUser: 0
+  runAsGroup: 0
+  fsGroup: 5050
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/pgadmin/values.yaml
+++ b/charts/stable/pgadmin/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: "5.6"
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/photoprism/values.yaml
+++ b/charts/stable/photoprism/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See [image docs](https://docs.photoprism.org/getting-started/config-options/) for more details.
 # @default -- See below
 env:

--- a/charts/stable/phpldapadmin/values.yaml
+++ b/charts/stable/phpldapadmin/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: "0.9.0"
 
-strategy:
-  type: Recreate
+
 
 
 service:

--- a/charts/stable/phpldapadmin/values.yaml
+++ b/charts/stable/phpldapadmin/values.yaml
@@ -6,8 +6,6 @@ image:
   tag: "0.9.0"
 
 
-
-
 service:
   main:
     enabled: true

--- a/charts/stable/piaware/SCALE/questions.yaml
+++ b/charts/stable/piaware/SCALE/questions.yaml
@@ -979,7 +979,7 @@ questions:
           label: "runAsNonRoot"
           schema:
             type: boolean
-            default: true
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -992,13 +992,13 @@ questions:
           description: "The UserID of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: runAsGroup
           label: "runAsGroup"
           description: The groupID this App of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: fsGroup
           label: "fsGroup"
           description: "The group that should own ALL storage."

--- a/charts/stable/piaware/SCALE/questions.yaml
+++ b/charts/stable/piaware/SCALE/questions.yaml
@@ -1004,7 +1004,7 @@ questions:
           description: "The group that should own ALL storage."
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: supplementalGroups
           label: "supplemental Groups"
           schema:

--- a/charts/stable/piaware/values.yaml
+++ b/charts/stable/piaware/values.yaml
@@ -22,7 +22,7 @@ securityContext:
 podSecurityContext:
   runAsUser: 0
   runAsGroup: 0
-  fsGroup: 568
+  fsGroup: 0
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"
 

--- a/charts/stable/piaware/values.yaml
+++ b/charts/stable/piaware/values.yaml
@@ -17,11 +17,11 @@ securityContext:
   privileged: true
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: true
-  runAsNonRoot: true
+  runAsNonRoot: false
 
 podSecurityContext:
-  runAsUser: 568
-  runAsGroup: 568
+  runAsUser: 0
+  runAsGroup: 0
   fsGroup: 568
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"

--- a/charts/stable/piaware/values.yaml
+++ b/charts/stable/piaware/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: true
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See [application docs](https://flightaware.com/adsb/piaware/advanced_configuration) for more details.
 # @default -- See below
 env:
@@ -26,11 +39,6 @@ service:
     ports:
       main:
         port: 8080
-
-
-securityContext:
-  # -- (bool) Privileged securityContext may be required if USB device is accessed directly through the host machine
-  privileged: true
 
 # -- Configure persistence settings for the chart under this key.
 # @default -- See values.yaml

--- a/charts/stable/plex/values.yaml
+++ b/charts/stable/plex/values.yaml
@@ -5,15 +5,19 @@ image:
   pullPolicy: IfNotPresent
   tag: v1.24.1.4931-1a38e63c6
 
-
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
 # 44=video 107=render
 podSecurityContext:
-  runAsNonRoot: true
   runAsUser: 568
   runAsGroup: 568
   fsGroup: 568
   supplementalGroups: [44, 107]
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/plex/values.yaml
+++ b/charts/stable/plex/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v1.24.1.4931-1a38e63c6
 
-strategy:
-  type: Recreate
+
 
 # 44=video 107=render
 podSecurityContext:

--- a/charts/stable/podgrab/values.yaml
+++ b/charts/stable/podgrab/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: Always
   tag: 1.0.0
 
-strategy:
-  type: Recreate
+
 
 # Configure the Security Context for the Pod
 podSecurityContext:

--- a/charts/stable/podgrab/values.yaml
+++ b/charts/stable/podgrab/values.yaml
@@ -5,14 +5,18 @@ image:
   pullPolicy: Always
   tag: 1.0.0
 
-
-
-# Configure the Security Context for the Pod
-podSecurityContext:
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
   runAsNonRoot: true
+
+podSecurityContext:
   runAsUser: 568
   runAsGroup: 568
   fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/postgresql/values.yaml
+++ b/charts/stable/postgresql/values.yaml
@@ -3,8 +3,7 @@ image:
   pullPolicy: IfNotPresent
   tag: "13.4"
 
-strategy:
-  type: Recreate
+
 
 
 service:

--- a/charts/stable/postgresql/values.yaml
+++ b/charts/stable/postgresql/values.yaml
@@ -4,8 +4,6 @@ image:
   tag: "13.4"
 
 
-
-
 service:
   main:
     enabled: true

--- a/charts/stable/pretend-youre-xyzzy/SCALE/questions.yaml
+++ b/charts/stable/pretend-youre-xyzzy/SCALE/questions.yaml
@@ -887,7 +887,7 @@ questions:
           description: "The group that should own ALL storage."
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: supplementalGroups
           label: "supplemental Groups"
           schema:

--- a/charts/stable/pretend-youre-xyzzy/SCALE/questions.yaml
+++ b/charts/stable/pretend-youre-xyzzy/SCALE/questions.yaml
@@ -862,7 +862,7 @@ questions:
           label: "runAsNonRoot"
           schema:
             type: boolean
-            default: true
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -875,13 +875,13 @@ questions:
           description: "The UserID of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: runAsGroup
           label: "runAsGroup"
           description: The groupID this App of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: fsGroup
           label: "fsGroup"
           description: "The group that should own ALL storage."

--- a/charts/stable/pretend-youre-xyzzy/values.yaml
+++ b/charts/stable/pretend-youre-xyzzy/values.yaml
@@ -22,7 +22,7 @@ securityContext:
 podSecurityContext:
   runAsUser: 0
   runAsGroup: 0
-  fsGroup: 568
+  fsGroup: 0
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"
 

--- a/charts/stable/pretend-youre-xyzzy/values.yaml
+++ b/charts/stable/pretend-youre-xyzzy/values.yaml
@@ -17,11 +17,11 @@ securityContext:
   privileged: false
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: true
-  runAsNonRoot: true
+  runAsNonRoot: false
 
 podSecurityContext:
-  runAsUser: 568
-  runAsGroup: 568
+  runAsUser: 0
+  runAsGroup: 0
   fsGroup: 568
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"

--- a/charts/stable/pretend-youre-xyzzy/values.yaml
+++ b/charts/stable/pretend-youre-xyzzy/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- Configures service settings for the chart.
 # @default -- See values.yaml
 service:

--- a/charts/stable/protonmail-bridge/SCALE/questions.yaml
+++ b/charts/stable/protonmail-bridge/SCALE/questions.yaml
@@ -1016,7 +1016,7 @@ questions:
           description: "The group that should own ALL storage."
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: supplementalGroups
           label: "supplemental Groups"
           schema:

--- a/charts/stable/protonmail-bridge/SCALE/questions.yaml
+++ b/charts/stable/protonmail-bridge/SCALE/questions.yaml
@@ -991,7 +991,7 @@ questions:
           label: "runAsNonRoot"
           schema:
             type: boolean
-            default: true
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1004,13 +1004,13 @@ questions:
           description: "The UserID of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: runAsGroup
           label: "runAsGroup"
           description: The groupID this App of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: fsGroup
           label: "fsGroup"
           description: "The group that should own ALL storage."

--- a/charts/stable/protonmail-bridge/values.yaml
+++ b/charts/stable/protonmail-bridge/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables.
 # @default -- See below
 env:

--- a/charts/stable/protonmail-bridge/values.yaml
+++ b/charts/stable/protonmail-bridge/values.yaml
@@ -22,7 +22,7 @@ securityContext:
 podSecurityContext:
   runAsUser: 0
   runAsGroup: 0
-  fsGroup: 568
+  fsGroup: 0
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"
 

--- a/charts/stable/protonmail-bridge/values.yaml
+++ b/charts/stable/protonmail-bridge/values.yaml
@@ -17,11 +17,11 @@ securityContext:
   privileged: false
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: true
-  runAsNonRoot: true
+  runAsNonRoot: false
 
 podSecurityContext:
-  runAsUser: 568
-  runAsGroup: 568
+  runAsUser: 0
+  runAsGroup: 0
   fsGroup: 568
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"

--- a/charts/stable/prowlarr/values.yaml
+++ b/charts/stable/prowlarr/values.yaml
@@ -13,10 +13,18 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
-podSecurityContext:
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
   runAsNonRoot: true
+
+podSecurityContext:
   runAsUser: 568
   runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 # -- environment variables.
 # @default -- See below

--- a/charts/stable/pyload/SCALE/questions.yaml
+++ b/charts/stable/pyload/SCALE/questions.yaml
@@ -1016,7 +1016,7 @@ questions:
           description: "The group that should own ALL storage."
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: supplementalGroups
           label: "supplemental Groups"
           schema:

--- a/charts/stable/pyload/SCALE/questions.yaml
+++ b/charts/stable/pyload/SCALE/questions.yaml
@@ -991,7 +991,7 @@ questions:
           label: "runAsNonRoot"
           schema:
             type: boolean
-            default: true
+            default: false
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -1004,13 +1004,13 @@ questions:
           description: "The UserID of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: runAsGroup
           label: "runAsGroup"
           description: The groupID this App of the user running the application"
           schema:
             type: int
-            default: 568
+            default: 0
         - variable: fsGroup
           label: "fsGroup"
           description: "The group that should own ALL storage."

--- a/charts/stable/pyload/values.yaml
+++ b/charts/stable/pyload/values.yaml
@@ -22,7 +22,7 @@ securityContext:
 podSecurityContext:
   runAsUser: 0
   runAsGroup: 0
-  fsGroup: 568
+  fsGroup: 0
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"
 

--- a/charts/stable/pyload/values.yaml
+++ b/charts/stable/pyload/values.yaml
@@ -17,11 +17,11 @@ securityContext:
   privileged: false
   readOnlyRootFilesystem: false
   allowPrivilegeEscalation: true
-  runAsNonRoot: true
+  runAsNonRoot: false
 
 podSecurityContext:
-  runAsUser: 568
-  runAsGroup: 568
+  runAsUser: 0
+  runAsGroup: 0
   fsGroup: 568
   supplementalGroups: []
   fsGroupChangePolicy: "OnRootMismatch"

--- a/charts/stable/pyload/values.yaml
+++ b/charts/stable/pyload/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See [image docs](https://docs.linuxserver.io/images/docker-pyload#environment-variables-e) for more details.
 # @default -- See below
 env:

--- a/charts/stable/qbittorrent/values.yaml
+++ b/charts/stable/qbittorrent/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v4.3.7
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 env: {}
     # TZ: UTC

--- a/charts/stable/qbittorrent/values.yaml
+++ b/charts/stable/qbittorrent/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v4.3.7
 
-strategy:
-  type: Recreate
+
 
 env: {}
     # TZ: UTC

--- a/charts/stable/radarr/values.yaml
+++ b/charts/stable/radarr/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v3.2.2.5080
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/radarr/values.yaml
+++ b/charts/stable/radarr/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v3.2.2.5080
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/readarr/values.yaml
+++ b/charts/stable/readarr/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v0.1.0.963
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/readarr/values.yaml
+++ b/charts/stable/readarr/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v0.1.0.963
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/reg/values.yaml
+++ b/charts/stable/reg/values.yaml
@@ -13,10 +13,18 @@ image:
   # -- image tag
   tag: v0.16.1
 
-podSecurityContext:
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
   runAsNonRoot: true
+
+podSecurityContext:
   runAsUser: 568
   runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 # -- environment variables. See more environment variables in the [reg documentation](https://github.com/genuinetools/reg).
 env:

--- a/charts/stable/resilio-sync/values.yaml
+++ b/charts/stable/resilio-sync/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: false
+
+podSecurityContext:
+  runAsUser: 0
+  runAsGroup: 0
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See [image docs](https://docs.linuxserver.io/images/docker-resilio-sync#environment-variables-e) for more details.
 # @default -- See below
 env:

--- a/charts/stable/sabnzbd/values.yaml
+++ b/charts/stable/sabnzbd/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v3.3.1
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/sabnzbd/values.yaml
+++ b/charts/stable/sabnzbd/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v3.3.1
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/ser2sock/values.yaml
+++ b/charts/stable/ser2sock/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: Always
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables. See [image docs](https://github.com/tenstartups/ser2sock) for more details.
 # @default -- See below
 env:
@@ -45,10 +58,6 @@ persistence:
     enabled: false
     type: hostPath
     mountPath: /dev/ttyUSB0
-
-securityContext:
-  # -- (bool) Privileged securityContext may be required if USB controller is accessed directly through the host machine
-  privileged:  # true
 
 # -- Affinity constraint rules to place the Pod on a specific node.
 # [[ref]](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)

--- a/charts/stable/sonarr/values.yaml
+++ b/charts/stable/sonarr/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v3.0.6.1265
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/sonarr/values.yaml
+++ b/charts/stable/sonarr/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v3.0.6.1265
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/syncthing/values.yaml
+++ b/charts/stable/syncthing/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: "1.18"
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/syncthing/values.yaml
+++ b/charts/stable/syncthing/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: "1.18"
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/tautulli/values.yaml
+++ b/charts/stable/tautulli/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v2.7.6
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/tautulli/values.yaml
+++ b/charts/stable/tautulli/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v2.7.6
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/thelounge/values.yaml
+++ b/charts/stable/thelounge/values.yaml
@@ -13,8 +13,6 @@ image:
   # -- image tag
   tag: 4.2.0-alpine
 
-
-
 # -- environment variables. See [image docs](https://hub.docker.com/r/thelounge/thelounge/) for more details.
 # @default -- See below
 env:

--- a/charts/stable/thelounge/values.yaml
+++ b/charts/stable/thelounge/values.yaml
@@ -13,8 +13,7 @@ image:
   # -- image tag
   tag: 4.2.0-alpine
 
-strategy:
-  type: Recreate
+
 
 # -- environment variables. See [image docs](https://hub.docker.com/r/thelounge/thelounge/) for more details.
 # @default -- See below

--- a/charts/stable/traefik/SCALE/questions.yaml
+++ b/charts/stable/traefik/SCALE/questions.yaml
@@ -1140,11 +1140,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/charts/stable/traefik/values.yaml
+++ b/charts/stable/traefik/values.yaml
@@ -5,6 +5,23 @@ image:
   tag: v2.5.2
   pullPolicy: IfNotPresent
 
+# -- Set the container security context
+# To run the container with ports below 1024 this will need to be adjust to run as root
+securityContext:
+  capabilities:
+    drop: [ALL]
+  privileged: false
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  runAsNonRoot: false
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- Use ingressClass. Ignored if Traefik version < 2.3 / kubernetes < 1.18.x
 ingressClass:
   # true is not unit-testable yet, pending https://github.com/rancher/helm-unittest/pull/12
@@ -273,19 +290,6 @@ serviceAccount:
   # If set, an existing service account is used
   # If not set, a service account is created automatically using the fullname template
   name: ""
-
-# -- Set the container security context
-# To run the container with ports below 1024 this will need to be adjust to run as root
-securityContext:
-  capabilities:
-    drop: [ALL]
-  readOnlyRootFilesystem: true
-  runAsGroup: 568
-  runAsNonRoot: true
-  runAsUser: 568
-
-podSecurityContext:
-  fsGroup: 568
 
 # -- SCALE Middleware Handlers
 middlewares:

--- a/charts/stable/transmission/values.yaml
+++ b/charts/stable/transmission/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: v3.00
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/transmission/values.yaml
+++ b/charts/stable/transmission/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: v3.00
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/truecommand/values.yaml
+++ b/charts/stable/truecommand/values.yaml
@@ -5,8 +5,6 @@ image:
   pullPolicy: IfNotPresent
   tag: "2.0"
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/truecommand/values.yaml
+++ b/charts/stable/truecommand/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: "2.0"
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/tvheadend/values.yaml
+++ b/charts/stable/tvheadend/values.yaml
@@ -5,8 +5,6 @@ image:
   pullPolicy: IfNotPresent
   tag: version-63784405
 
-
-
 # See https://github.com/linuxserver/docker-tvheadend#parameters
 env: {}
   # PUID: 1000

--- a/charts/stable/tvheadend/values.yaml
+++ b/charts/stable/tvheadend/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: version-63784405
 
-strategy:
-  type: Recreate
+
 
 # See https://github.com/linuxserver/docker-tvheadend#parameters
 env: {}

--- a/charts/stable/unifi/values.yaml
+++ b/charts/stable/unifi/values.yaml
@@ -5,8 +5,7 @@ image:
   tag: v6.2.26
   pullPolicy: IfNotPresent
 
-strategy:
-  type: Recreate
+
 
 envTpl:
   # Permissions Settings

--- a/charts/stable/unifi/values.yaml
+++ b/charts/stable/unifi/values.yaml
@@ -5,8 +5,6 @@ image:
   tag: v6.2.26
   pullPolicy: IfNotPresent
 
-
-
 envTpl:
   # Permissions Settings
   UNIFI_GID: "{{ .Values.env.PUID }}"

--- a/charts/stable/unpackerr/values.yaml
+++ b/charts/stable/unpackerr/values.yaml
@@ -5,7 +5,18 @@ image:
   pullPolicy: IfNotPresent
   tag: 0.9.7
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 service:
   main:

--- a/charts/stable/unpackerr/values.yaml
+++ b/charts/stable/unpackerr/values.yaml
@@ -5,8 +5,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 0.9.7
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/vaultwarden/values.yaml
+++ b/charts/stable/vaultwarden/values.yaml
@@ -5,6 +5,19 @@ image:
   pullPolicy: IfNotPresent
   tag: 1.22.2
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 postgresqlImage:
   repository: postgres
   pullPolicy: IfNotPresent

--- a/charts/stable/vaultwarden/values.yaml
+++ b/charts/stable/vaultwarden/values.yaml
@@ -24,8 +24,6 @@ postgresqlImage:
   tag: 13.4-alpine
 
 
-
-
 service:
   main:
     ports:

--- a/charts/stable/vaultwarden/values.yaml
+++ b/charts/stable/vaultwarden/values.yaml
@@ -11,8 +11,7 @@ postgresqlImage:
   tag: 13.4-alpine
 
 
-strategy:
-  type: Recreate
+
 
 service:
   main:

--- a/charts/stable/xteve/values.yaml
+++ b/charts/stable/xteve/values.yaml
@@ -13,6 +13,19 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
+
 # -- environment variables.
 # @default -- See below
 env:

--- a/charts/stable/zwavejs2mqtt/values.yaml
+++ b/charts/stable/zwavejs2mqtt/values.yaml
@@ -7,15 +7,19 @@ image:
   pullPolicy: IfNotPresent
   tag: 5.5.3
 
-
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
 # 5=tty 20=dialout 24=cdrom
 podSecurityContext:
-  runAsNonRoot: true
   runAsUser: 568
   runAsGroup: 568
   fsGroup: 568
   supplementalGroups: [5, 20, 24]
+  fsGroupChangePolicy: "OnRootMismatch"
 
 # # See more environment variables in the zwavejs2mqtt documentation
 # https://zwave-js.github.io/zwavejs2mqtt/#/guide/env-vars

--- a/charts/stable/zwavejs2mqtt/values.yaml
+++ b/charts/stable/zwavejs2mqtt/values.yaml
@@ -7,8 +7,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 5.5.3
 
-strategy:
-  type: Recreate
+
 
 # 5=tty 20=dialout 24=cdrom
 podSecurityContext:

--- a/templates/app/SCALE/questions.yaml
+++ b/templates/app/SCALE/questions.yaml
@@ -589,6 +589,11 @@ questions:
           schema:
             type: boolean
             default: false
+        - variable: runAsNonRoot
+          label: "runAsNonRoot"
+          schema:
+            type: boolean
+            default: true
 
   - variable: podSecurityContext
     group: "Security and Permissions"
@@ -596,11 +601,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: runAsNonRoot
-          label: "runAsNonRoot"
-          schema:
-            type: boolean
-            default: true
         - variable: runAsUser
           label: "runAsUser"
           description: "The UserID of the user running the application"

--- a/templates/app/values.yaml
+++ b/templates/app/values.yaml
@@ -10,7 +10,18 @@ image:
   pullPolicy: IfNotPresent
   tag: 1.0.0
 
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
+  runAsNonRoot: true
 
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  supplementalGroups: []
+  fsGroupChangePolicy: "OnRootMismatch"
 
 # See more environment variables in the ${CHARTNAME} documentation
 # https://${CHARTNAME}.org/docs

--- a/templates/app/values.yaml
+++ b/templates/app/values.yaml
@@ -10,8 +10,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 1.0.0
 
-strategy:
-  type: Recreate
+
 
 # See more environment variables in the ${CHARTNAME} documentation
 # https://${CHARTNAME}.org/docs


### PR DESCRIPTION
**Description**
Summary:

- Removed `strategy` from all `values.yaml`
- For all apps that have `podSecurityContext` / `securityContext` defined in `questions.yaml`, I copied the default values to `values.yaml`
- For apps that failed tests, I checked and all was due to permissions. So changed `runAsUser`, `runAsGroup` to `0` (left `fsGroup` to `568`) and `runAsNonRoot` to `false`, in both `values.yaml` AND `questions.yaml`
- Nextcloud had no `securityContext` defined in `questions.yaml`, so I ported only `podSecurityContext`.


**Type of change**

- [ ] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
