### PR TITLE
chore: move all LSIO containers to github registry

### DIFF
--- a/charts/stable/airsonic/SCALE/ix_values.yaml
+++ b/charts/stable/airsonic/SCALE/ix_values.yaml
@@ -6,7 +6,7 @@
 
 image:
   # -- image repository
-  repository: linuxserver/airsonic
+  repository: ghcr.io/linuxserver/airsonic
   # -- image tag
   tag: version-v10.6.2
   # -- image pull policy

--- a/charts/stable/airsonic/values.yaml
+++ b/charts/stable/airsonic/values.yaml
@@ -7,7 +7,7 @@
 
 image:
   # -- image repository
-  repository: linuxserver/airsonic
+  repository: ghcr.io/linuxserver/airsonic
   # -- image tag
   tag: version-v10.6.2
   # -- image pull policy

--- a/charts/stable/calibre-web/SCALE/ix_values.yaml
+++ b/charts/stable/calibre-web/SCALE/ix_values.yaml
@@ -5,7 +5,7 @@
 ##
 
 image:
-  repository: linuxserver/calibre-web
+  repository: ghcr.io/linuxserver/calibre-web
   pullPolicy: IfNotPresent
   tag: version-0.6.12
 

--- a/charts/stable/calibre-web/values.yaml
+++ b/charts/stable/calibre-web/values.yaml
@@ -1,7 +1,7 @@
 # Default values for Calibre-Web.
 
 image:
-  repository: linuxserver/calibre-web
+  repository: ghcr.io/linuxserver/calibre-web
   pullPolicy: IfNotPresent
   tag: version-0.6.12
 

--- a/charts/stable/calibre/SCALE/ix_values.yaml
+++ b/charts/stable/calibre/SCALE/ix_values.yaml
@@ -5,7 +5,7 @@
 ##
 
 image:
-  repository: linuxserver/calibre
+  repository: ghcr.io/linuxserver/calibre
   pullPolicy: IfNotPresent
   tag: version-v5.26.0
 

--- a/charts/stable/calibre/values.yaml
+++ b/charts/stable/calibre/values.yaml
@@ -10,7 +10,7 @@
 # -- This is the default, you can also use requarks/wiki
 image:
   # -- image repository
-  repository: linuxserver/calibre
+  repository: ghcr.io/linuxserver/calibre
   # -- image tag
   tag: version-v5.26.0
   # -- image pull policy

--- a/charts/stable/deluge/SCALE/ix_values.yaml
+++ b/charts/stable/deluge/SCALE/ix_values.yaml
@@ -5,7 +5,7 @@
 ##
 
 image:
-  repository: linuxserver/deluge
+  repository: ghcr.io/linuxserver/deluge
   pullPolicy: IfNotPresent
   tag: version-2.0.3-2201906121747ubuntu18.04.1
 

--- a/charts/stable/deluge/values.yaml
+++ b/charts/stable/deluge/values.yaml
@@ -1,7 +1,7 @@
 # Default values for deluge.
 
 image:
-  repository: linuxserver/deluge
+  repository: ghcr.io/linuxserver/deluge
   pullPolicy: IfNotPresent
   tag: version-2.0.3-2201906121747ubuntu18.04.1
 

--- a/charts/stable/freshrss/SCALE/ix_values.yaml
+++ b/charts/stable/freshrss/SCALE/ix_values.yaml
@@ -5,7 +5,7 @@
 ##
 
 image:
-  repository: linuxserver/freshrss
+  repository: ghcr.io/linuxserver/freshrss
   pullPolicy: IfNotPresent
   tag: version-1.18.1
 

--- a/charts/stable/freshrss/values.yaml
+++ b/charts/stable/freshrss/values.yaml
@@ -1,7 +1,7 @@
 # Default values for FreshRSS.
 
 image:
-  repository: linuxserver/freshrss
+  repository: ghcr.io/linuxserver/freshrss
   pullPolicy: IfNotPresent
   tag: version-1.18.1
 

--- a/charts/stable/grocy/SCALE/ix_values.yaml
+++ b/charts/stable/grocy/SCALE/ix_values.yaml
@@ -5,7 +5,7 @@
 ##
 
 image:
-  repository: linuxserver/grocy
+  repository: ghcr.io/linuxserver/grocy
   tag: version-v3.1.1
   pullPolicy: IfNotPresent
 

--- a/charts/stable/grocy/values.yaml
+++ b/charts/stable/grocy/values.yaml
@@ -1,7 +1,7 @@
 # Default values for grocy.
 
 image:
-  repository: linuxserver/grocy
+  repository: ghcr.io/linuxserver/grocy
   tag: version-v3.1.1
   pullPolicy: IfNotPresent
 

--- a/charts/stable/healthchecks/SCALE/ix_values.yaml
+++ b/charts/stable/healthchecks/SCALE/ix_values.yaml
@@ -5,7 +5,7 @@
 ##
 
 image:
-  repository: linuxserver/healthchecks
+  repository: ghcr.io/linuxserver/healthchecks
   pullPolicy: IfNotPresent
   tag: version-v1.22.0
 

--- a/charts/stable/healthchecks/values.yaml
+++ b/charts/stable/healthchecks/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   # -- image repository
-  repository: linuxserver/healthchecks
+  repository: ghcr.io/linuxserver/healthchecks
   # -- image tag
   tag: version-v1.22.0
   # -- image pull policy

--- a/charts/stable/heimdall/SCALE/ix_values.yaml
+++ b/charts/stable/heimdall/SCALE/ix_values.yaml
@@ -5,7 +5,7 @@
 ##
 
 image:
-  repository: linuxserver/heimdall
+  repository: ghcr.io/linuxserver/heimdall
   tag: version-2.2.2
   pullPolicy: IfNotPresent
 

--- a/charts/stable/heimdall/values.yaml
+++ b/charts/stable/heimdall/values.yaml
@@ -1,7 +1,7 @@
 # Default values for grocy.
 
 image:
-  repository: linuxserver/heimdall
+  repository: ghcr.io/linuxserver/heimdall
   tag: version-2.2.2
   pullPolicy: IfNotPresent
 

--- a/charts/stable/lazylibrarian/SCALE/ix_values.yaml
+++ b/charts/stable/lazylibrarian/SCALE/ix_values.yaml
@@ -5,7 +5,7 @@
 ##
 
 image:
-  repository: linuxserver/lazylibrarian
+  repository: ghcr.io/linuxserver/lazylibrarian
   pullPolicy: IfNotPresent
   tag: latest
 

--- a/charts/stable/lazylibrarian/values.yaml
+++ b/charts/stable/lazylibrarian/values.yaml
@@ -1,7 +1,7 @@
 # Default values for LazyLibrarian.
 
 image:
-  repository: linuxserver/lazylibrarian
+  repository: ghcr.io/linuxserver/lazylibrarian
   pullPolicy: IfNotPresent
   tag: latest
 

--- a/charts/stable/librespeed/SCALE/ix_values.yaml
+++ b/charts/stable/librespeed/SCALE/ix_values.yaml
@@ -5,7 +5,7 @@
 ##
 
 image:
-  repository: linuxserver/librespeed
+  repository: ghcr.io/linuxserver/librespeed
   pullPolicy: IfNotPresent
   tag: version-5.2.4
 

--- a/charts/stable/librespeed/values.yaml
+++ b/charts/stable/librespeed/values.yaml
@@ -7,7 +7,7 @@
 
 image:
   # -- image repository
-  repository: linuxserver/librespeed
+  repository: ghcr.io/linuxserver/librespeed
   # -- image tag
   tag: version-5.2.4
   # -- image pull policy

--- a/charts/stable/tvheadend/SCALE/ix_values.yaml
+++ b/charts/stable/tvheadend/SCALE/ix_values.yaml
@@ -5,7 +5,7 @@
 ##
 
 image:
-  repository: linuxserver/tvheadend
+  repository: ghcr.io/linuxserver/tvheadend
   pullPolicy: IfNotPresent
   tag: version-63784405
 

--- a/charts/stable/tvheadend/values.yaml
+++ b/charts/stable/tvheadend/values.yaml
@@ -1,7 +1,7 @@
 # Default values for tvheadend.
 
 image:
-  repository: linuxserver/tvheadend
+  repository: ghcr.io/linuxserver/tvheadend
   pullPolicy: IfNotPresent
   tag: version-63784405
 


### PR DESCRIPTION
**Description**
It seems we mixed dockerhub with github-registry for LSIO containers.
This standardises to move those to github-registry to speedup tests (caching) and prevent rate-limiting

**Type of change**

- [ ] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
