### PR TITLE
chore: move most remaining Apps to GHCR mirror

### DIFF
--- a/charts/stable/collabora-online/SCALE/ix_values.yaml
+++ b/charts/stable/collabora-online/SCALE/ix_values.yaml
@@ -5,8 +5,8 @@
 ##
 
 image:
-  repository: collabora/code
-  tag: 6.4.10.10
+  repository: ghcr.io/truecharts/collabora
+  tag: v6.4.10.10
   pullPolicy: IfNotPresent
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/collabora-online/values.yaml
+++ b/charts/stable/collabora-online/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: collabora/code
-  tag: 6.4.10.10
+  repository: ghcr.io/truecharts/collabora
+  tag: v6.4.10.10
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/stable/deconz/SCALE/ix_values.yaml
+++ b/charts/stable/deconz/SCALE/ix_values.yaml
@@ -5,9 +5,9 @@
 ##
 
 image:
-  repository: marthoc/deconz
+  repository: ghcr.io/truecharts/deconz
   pullPolicy: IfNotPresent
-  tag: 2.12.06
+  tag: v2.12.06
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/deconz/values.yaml
+++ b/charts/stable/deconz/values.yaml
@@ -7,9 +7,9 @@
 
 image:
   # -- image repository
-  repository: marthoc/deconz
+  repository: ghcr.io/truecharts/deconz
     # -- image tag
-  tag: 2.12.06
+  tag: v2.12.06
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/dizquetv/SCALE/ix_values.yaml
+++ b/charts/stable/dizquetv/SCALE/ix_values.yaml
@@ -5,9 +5,9 @@
 ##
 
 image:
-  repository: vexorian/dizquetv
+  repository: ghcr.io/truecharts/dizquetv
   pullPolicy: IfNotPresent
-  tag: 1.4.3
+  tag: v1.4.3
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/dizquetv/values.yaml
+++ b/charts/stable/dizquetv/values.yaml
@@ -7,11 +7,11 @@
 
 image:
   # -- image repository
-  repository: vexorian/dizquetv
+  repository: ghcr.io/truecharts/dizquetv
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: 1.4.3
+  tag: v1.4.3
 
 # -- environment variables. See more environment variables in the [dizquetv documentation](https://hub.docker.com/r/vexorian/dizquetv).
 # @default -- See below

--- a/charts/stable/mosquitto/SCALE/ix_values.yaml
+++ b/charts/stable/mosquitto/SCALE/ix_values.yaml
@@ -6,9 +6,9 @@
 
 image:
   # -- image repository
-  repository: ghcr.io/truecharts/eclipse-mosquitto
+  repository: eclipse-mosquitto
   # -- image tag
-  tag: v2.0.12
+  tag: 2.0.12
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -2,9 +2,9 @@
 
 image:
   # -- image repository
-  repository: ghcr.io/truecharts/eclipse-mosquitto
+  repository: eclipse-mosquitto
   # -- image tag
-  tag: v2.0.12
+  tag: 2.0.12
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/navidrome/SCALE/ix_values.yaml
+++ b/charts/stable/navidrome/SCALE/ix_values.yaml
@@ -5,9 +5,9 @@
 ##
 
 image:
-  repository: deluan/navidrome
+  repository: ghcr.io/truecharts/navidrome
   pullPolicy: IfNotPresent
-  tag: 0.45.1
+  tag: v0.45.1
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/navidrome/values.yaml
+++ b/charts/stable/navidrome/values.yaml
@@ -1,9 +1,9 @@
 # Default values for Navidrome.
 
 image:
-  repository: deluan/navidrome
+  repository: ghcr.io/truecharts/navidrome
   pullPolicy: IfNotPresent
-  tag: 0.45.1
+  tag: v0.45.1
 
 securityContext:
   privileged: false

--- a/charts/stable/nextcloud/SCALE/ix_values.yaml
+++ b/charts/stable/nextcloud/SCALE/ix_values.yaml
@@ -5,9 +5,9 @@
 ##
 
 image:
-  repository: nextcloud
+  repository: ghcr.io/truecharts/nextcloud
   pullPolicy: IfNotPresent
-  tag: 22.1.1
+  tag: v22.1.1
 
 postgresqlImage:
   repository: postgres

--- a/charts/stable/nextcloud/SCALE/ix_values.yaml
+++ b/charts/stable/nextcloud/SCALE/ix_values.yaml
@@ -5,9 +5,9 @@
 ##
 
 image:
-  repository: ghcr.io/truecharts/nextcloud
+  repository: nextcloud
   pullPolicy: IfNotPresent
-  tag: v22.1.1
+  tag: 22.1.1
 
 postgresqlImage:
   repository: postgres

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -1,9 +1,9 @@
 # Default values for Bitwarden.
 
 image:
-  repository: ghcr.io/truecharts/nextcloud
+  repository: nextcloud
   pullPolicy: IfNotPresent
-  tag: v22.1.1
+  tag: 22.1.1
 
 podSecurityContext:
   runAsUser: 0

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -1,9 +1,9 @@
 # Default values for Bitwarden.
 
 image:
-  repository: nextcloud
+  repository: ghcr.io/truecharts/nextcloud
   pullPolicy: IfNotPresent
-  tag: 22.1.1
+  tag: v22.1.1
 
 podSecurityContext:
   runAsUser: 0

--- a/charts/stable/octoprint/SCALE/ix_values.yaml
+++ b/charts/stable/octoprint/SCALE/ix_values.yaml
@@ -5,9 +5,9 @@
 ##
 
 image:
-  repository: octoprint/octoprint
+  repository: ghcr.io/truecharts/octoprint
   pullPolicy: IfNotPresent
-  tag: 1.6.1
+  tag: v1.6.1
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/octoprint/values.yaml
+++ b/charts/stable/octoprint/values.yaml
@@ -7,9 +7,9 @@
 
 image:
   # -- image repository
-  repository: octoprint/octoprint
+  repository: ghcr.io/truecharts/octoprint
   # -- image tag
-  tag: 1.6.1
+  tag: v1.6.1
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/openldap/SCALE/ix_values.yaml
+++ b/charts/stable/openldap/SCALE/ix_values.yaml
@@ -4,9 +4,9 @@
 # Example: Everything under "image" is not included in questions.yaml but is included here.
 ##
 image:
-  repository: osixia/openldap
+  repository: ghcr.io/truecharts/openldap
   pullPolicy: IfNotPresent
-  tag: 1.5.0
+  tag: v1.5.0
 
 controller:
   # -- Set the controller type.

--- a/charts/stable/openldap/values.yaml
+++ b/charts/stable/openldap/values.yaml
@@ -1,9 +1,9 @@
 # Default values for Bitwarden.
 
 image:
-  repository: osixia/openldap
+  repository: ghcr.io/truecharts/openldap
   pullPolicy: IfNotPresent
-  tag: 1.5.0
+  tag: v1.5.0
 
 controller:
   # -- Set the controller type.

--- a/charts/stable/owncloud-ocis/SCALE/ix_values.yaml
+++ b/charts/stable/owncloud-ocis/SCALE/ix_values.yaml
@@ -5,9 +5,9 @@
 ##
 
 image:
-  repository: owncloud/ocis
+  repository: ghcr.io/truecharts/ocis
   pullPolicy: IfNotPresent
-  tag: 1.11.0
+  tag: v1.11.0
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/owncloud-ocis/values.yaml
+++ b/charts/stable/owncloud-ocis/values.yaml
@@ -7,9 +7,9 @@
 
 image:
   # -- image repository
-  repository: owncloud/ocis
+  repository: ghcr.io/truecharts/ocis
   # -- image tag
-  tag: 1.11.0
+  tag: v1.11.0
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/piaware/SCALE/ix_values.yaml
+++ b/charts/stable/piaware/SCALE/ix_values.yaml
@@ -5,9 +5,9 @@
 ##
 
 image:
-  repository: mikenye/piaware
+  repository: ghcr.io/truecharts/piaware
   pullPolicy: IfNotPresent
-  tag: v6.0
+  tag: v6.1
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/piaware/values.yaml
+++ b/charts/stable/piaware/values.yaml
@@ -7,9 +7,9 @@
 
 image:
   # -- image repository
-  repository: mikenye/piaware
+  repository: ghcr.io/truecharts/piaware
   # -- image tag
-  tag: v6.0
+  tag: v6.1
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/pihole/SCALE/ix_values.yaml
+++ b/charts/stable/pihole/SCALE/ix_values.yaml
@@ -5,7 +5,7 @@
 ##
 
 image:
-  repository: pihole/pihole
+  repository: ghcr.io/truecharts/pihole
   pullPolicy: IfNotPresent
   tag: v5.8.1
 

--- a/charts/stable/pihole/values.yaml
+++ b/charts/stable/pihole/values.yaml
@@ -1,7 +1,7 @@
 # Default values for Jackett.
 
 image:
-  repository: pihole/pihole
+  repository: ghcr.io/truecharts/pihole
   pullPolicy: IfNotPresent
   tag: v5.8.1
 

--- a/charts/stable/syncthing/SCALE/ix_values.yaml
+++ b/charts/stable/syncthing/SCALE/ix_values.yaml
@@ -5,9 +5,9 @@
 ##
 
 image:
-  repository: syncthing/syncthing
+  repository: ghcr.io/truecharts/syncthing
   pullPolicy: IfNotPresent
-  tag: "1.18"
+  tag: v1.18
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/syncthing/values.yaml
+++ b/charts/stable/syncthing/values.yaml
@@ -1,9 +1,9 @@
 # Default values for Syncthing.
 
 image:
-  repository: syncthing/syncthing
+  repository: ghcr.io/truecharts/syncthing
   pullPolicy: IfNotPresent
-  tag: "1.18"
+  tag: v1.18.2
 
 securityContext:
   privileged: false

--- a/charts/stable/thelounge/SCALE/ix_values.yaml
+++ b/charts/stable/thelounge/SCALE/ix_values.yaml
@@ -6,11 +6,11 @@
 
 image:
   # -- image repository
-  repository: thelounge/thelounge
+  repository: ghcr.io/truecharts/thelounge
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: 4.2.0-alpine
+  tag: v4.2.0
 
 
 ##

--- a/charts/stable/thelounge/values.yaml
+++ b/charts/stable/thelounge/values.yaml
@@ -7,11 +7,11 @@
 
 image:
   # -- image repository
-  repository: thelounge/thelounge
+  repository: ghcr.io/truecharts/thelounge
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: 4.2.0-alpine
+  tag: v4.2.0
 
 # -- environment variables. See [image docs](https://hub.docker.com/r/thelounge/thelounge/) for more details.
 # @default -- See below

--- a/charts/stable/traefik/SCALE/ix_values.yaml
+++ b/charts/stable/traefik/SCALE/ix_values.yaml
@@ -1,6 +1,6 @@
 # Default values for Traefik
 image:
-  repository: ghcr.io/truecharts/traefik
+  repository: traefik
   # defaults to appVersion
   tag: v2.5.2
   pullPolicy: IfNotPresent

--- a/charts/stable/traefik/values.yaml
+++ b/charts/stable/traefik/values.yaml
@@ -1,6 +1,6 @@
 # Default values for Traefik
 image:
-  repository: ghcr.io/truecharts/traefik
+  repository: traefik
   # defaults to appVersion
   tag: v2.5.2
   pullPolicy: IfNotPresent

--- a/charts/stable/zwavejs2mqtt/SCALE/ix_values.yaml
+++ b/charts/stable/zwavejs2mqtt/SCALE/ix_values.yaml
@@ -5,9 +5,9 @@
 ##
 
 image:
-  repository: zwavejs/zwavejs2mqtt
+  repository: ghcr.io/truecharts/zwavejs2mqtt
   pullPolicy: IfNotPresent
-  tag: 5.5.3
+  tag: v5.5.4
 
 probes:
   liveness:

--- a/charts/stable/zwavejs2mqtt/values.yaml
+++ b/charts/stable/zwavejs2mqtt/values.yaml
@@ -3,9 +3,9 @@
 # https://github.com/k8s-at-home/charts/tree/master/charts/common
 
 image:
-  repository: zwavejs/zwavejs2mqtt
+  repository: ghcr.io/truecharts/zwavejs2mqtt
   pullPolicy: IfNotPresent
-  tag: 5.5.3
+  tag: v5.5.4
 
 securityContext:
   privileged: false


### PR DESCRIPTION
**Description**
This moves most of the remaining Apps to our GHCR mirror. It should prevent any issues with dockerhub limits for those apps in the future, untill upstream apps start hosting their apps elsewhere aswell.

It also removes some mirror references where those are towards dockerhub official or verified-publishers, as those do not have ratelimits

**Type of change**

- [X] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
