### PR TITLE
feat: pin all container references to digests

### DIFF
--- a/charts/incubator/custom-app/values.yaml
+++ b/charts/incubator/custom-app/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/jackett
   pullPolicy: IfNotPresent
-  tag: v0.18.686
+  tag: v0.18.686@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/incubator/oscam/SCALE/ix_values.yaml
+++ b/charts/incubator/oscam/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/oscam
   pullPolicy: IfNotPresent
-  tag: version-11693
+  tag: version-11693@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/incubator/oscam/values.yaml
+++ b/charts/incubator/oscam/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/linuxserver/oscam
   pullPolicy: IfNotPresent
-  tag: version-11693
+  tag: version-11693@sha256:42
 
 env:
   TZ: UTC

--- a/charts/incubator/sogo/SCALE/ix_values.yaml
+++ b/charts/incubator/sogo/SCALE/ix_values.yaml
@@ -6,12 +6,12 @@
 image:
   repository: ghcr.io/truecharts/sogo
   pullPolicy: IfNotPresent
-  tag: v5.2.0
+  tag: v5.2.0@sha256:42
 
 postgresqlImage:
   repository: postgres
   pullPolicy: IfNotPresent
-  tag: 13.4-alpine
+  tag: 13.4-alpine@sha256:42
 
 initContainers:
   - name: init-postgresdb

--- a/charts/incubator/sogo/values.yaml
+++ b/charts/incubator/sogo/values.yaml
@@ -2,12 +2,12 @@
 image:
   repository: ghcr.io/truecharts/sogo
   pullPolicy: IfNotPresent
-  tag: v5.2.0
+  tag: v5.2.0@sha256:42
 
 postgresqlImage:
   repository: postgres
   pullPolicy: IfNotPresent
-  tag: 13.4-alpine
+  tag: 13.4-alpine@sha256:42
 
 # -- services
 service:

--- a/charts/library/common-test/ci/basic-values.yaml
+++ b/charts/library/common-test/ci/basic-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: b4bz/homer
-  tag: latest
+  tag: latest@sha256:42
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/library/common-test/values.yaml
+++ b/charts/library/common-test/values.yaml
@@ -1,4 +1,4 @@
 image:
   repository: ghcr.io/truecharts/homer
-  tag: latest
+  tag: latest@sha256:42
   pullPolicy: IfNotPresent

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -4,7 +4,7 @@ openvpnImage:
   # -- Specify the openvpn client image
   repository: dperson/openvpn-client
   # -- Specify the openvpn client image tag
-  tag: latest
+  tag: latest@sha256:42
   # -- Specify the openvpn client image pull policy
   pullPolicy: IfNotPresent
 
@@ -15,7 +15,7 @@ wireguardImage:
   # -- Specify the WireGuard image
   repository: ghcr.io/k8s-at-home/wireguard
   # -- Specify the WireGuard image tag
-  tag: v1.0.20210424
+  tag: v1.0.20210424@sha256:42
   # -- Specify the WireGuard image pull policy
   pullPolicy: IfNotPresent
 
@@ -23,7 +23,7 @@ promtailImage:
   # -- Specify the promtail image
   repository: ghcr.io/truecharts/promtail
   # -- Specify the promtail image tag
-  tag: v2.3.0
+  tag: v2.3.0@sha256:42
   # -- Specify the promtail image pull policy
   pullPolicy: IfNotPresent
 
@@ -32,7 +32,7 @@ netshootImage:
   # -- Specify the netshoot image
   repository: nicolaka/netshoot
   # -- Specify the netshoot image tag
-  tag: latest
+  tag: latest@sha256:42
   # -- Specify the netshoot image pull policy
   pullPolicy: Always
 
@@ -40,7 +40,7 @@ codeserverImage:
   # -- Specify the code-server image
   repository: ghcr.io/truecharts/code-server
   # -- Specify the code-server image tag
-  tag: 3.9.2
+  tag: 3.9.2@sha256:42
   # -- Specify the code-server image pull policy
   pullPolicy: IfNotPresent
 
@@ -48,7 +48,7 @@ alpineImage:
   # -- Specify the code-server image
   repository: ghcr.io/truecharts/alpine
   # -- Specify the code-server image tag
-  tag: v3.14.1
+  tag: v3.14.1@sha256:42
   # -- Specify the code-server image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/airsonic/SCALE/ix_values.yaml
+++ b/charts/stable/airsonic/SCALE/ix_values.yaml
@@ -8,7 +8,7 @@ image:
   # -- image repository
   repository: ghcr.io/linuxserver/airsonic
   # -- image tag
-  tag: version-v10.6.2
+  tag: version-v10.6.2@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/airsonic/values.yaml
+++ b/charts/stable/airsonic/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/linuxserver/airsonic
   # -- image tag
-  tag: version-v10.6.2
+  tag: version-v10.6.2@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/appdaemon/SCALE/ix_values.yaml
+++ b/charts/stable/appdaemon/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: acockburn/appdaemon
   pullPolicy: IfNotPresent
-  tag: "4.1.0"
+  tag: "4.1.0"@sha256:42
 
 
 ##

--- a/charts/stable/appdaemon/values.yaml
+++ b/charts/stable/appdaemon/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: ghcr.io/k8s-at-home/appdaemon
   pullPolicy: IfNotPresent
-  tag: "v4.0.8"
+  tag: "v4.0.8"@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/authelia/SCALE/ix_values.yaml
+++ b/charts/stable/authelia/SCALE/ix_values.yaml
@@ -7,12 +7,12 @@
 image:
   repository: ghcr.io/authelia/authelia
   pullPolicy: IfNotPresent
-  tag: "4.30.4"
+  tag: "4.30.4"@sha256:42
 
 postgresqlImage:
   repository: postgres
   pullPolicy: IfNotPresent
-  tag: 13.4-alpine
+  tag: 13.4-alpine@sha256:42
 
 
 enableServiceLinks: false

--- a/charts/stable/authelia/values.yaml
+++ b/charts/stable/authelia/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/authelia/authelia
   pullPolicy: IfNotPresent
-  tag: "4.30.4"
+  tag: "4.30.4"@sha256:42
 
 securityContext:
   privileged: false
@@ -21,7 +21,7 @@ podSecurityContext:
 postgresqlImage:
   repository: postgres
   pullPolicy: IfNotPresent
-  tag: 13.4-alpine
+  tag: 13.4-alpine@sha256:42
 
 command: ["authelia"]
 args: ["--config=/configuration.yaml"]

--- a/charts/stable/bazarr/SCALE/ix_values.yaml
+++ b/charts/stable/bazarr/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/bazarr
   pullPolicy: IfNotPresent
-  tag: v0.9.8
+  tag: v0.9.8@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/bazarr/values.yaml
+++ b/charts/stable/bazarr/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/bazarr
   pullPolicy: IfNotPresent
-  tag: v0.9.8
+  tag: v0.9.8@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/booksonic-air/SCALE/ix_values.yaml
+++ b/charts/stable/booksonic-air/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/booksonic-air
   pullPolicy: IfNotPresent
-  tag: version-v2009.1.0
+  tag: version-v2009.1.0@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/booksonic-air/values.yaml
+++ b/charts/stable/booksonic-air/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: version-v2009.1.0
+  tag: version-v2009.1.0@sha256:42
 
 # See more environment variables in the [booksonic-air documentation](https://github.com/linuxserver/docker-booksonic-air#parameters)
 # @default -- See below

--- a/charts/stable/calibre-web/SCALE/ix_values.yaml
+++ b/charts/stable/calibre-web/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/calibre-web
   pullPolicy: IfNotPresent
-  tag: version-0.6.12
+  tag: version-0.6.12@sha256:42
 
 
 ##

--- a/charts/stable/calibre-web/values.yaml
+++ b/charts/stable/calibre-web/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/linuxserver/calibre-web
   pullPolicy: IfNotPresent
-  tag: version-0.6.12
+  tag: version-0.6.12@sha256:42
 
 service:
   main:

--- a/charts/stable/calibre/SCALE/ix_values.yaml
+++ b/charts/stable/calibre/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/calibre
   pullPolicy: IfNotPresent
-  tag: version-v5.26.0
+  tag: version-v5.26.0@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/calibre/values.yaml
+++ b/charts/stable/calibre/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- image repository
   repository: ghcr.io/linuxserver/calibre
   # -- image tag
-  tag: version-v5.26.0
+  tag: version-v5.26.0@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/collabora-online/SCALE/ix_values.yaml
+++ b/charts/stable/collabora-online/SCALE/ix_values.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: ghcr.io/truecharts/collabora
-  tag: v6.4.10.10
+  tag: v6.4.10.10@sha256:42
   pullPolicy: IfNotPresent
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/collabora-online/values.yaml
+++ b/charts/stable/collabora-online/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/truecharts/collabora
-  tag: v6.4.10.10
+  tag: v6.4.10.10@sha256:42
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/stable/deconz/SCALE/ix_values.yaml
+++ b/charts/stable/deconz/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/deconz
   pullPolicy: IfNotPresent
-  tag: v2.12.06
+  tag: v2.12.06@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/deconz/values.yaml
+++ b/charts/stable/deconz/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/truecharts/deconz
     # -- image tag
-  tag: v2.12.06
+  tag: v2.12.06@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/deepstack-cpu/SCALE/ix_values.yaml
+++ b/charts/stable/deepstack-cpu/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: deepquestai/deepstack
   pullPolicy: IfNotPresent
-  tag: cpu-2021.02.1
+  tag: cpu-2021.02.1@sha256:42
 
 envTpl:
   # Permissions Settings

--- a/charts/stable/deepstack-cpu/values.yaml
+++ b/charts/stable/deepstack-cpu/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: deepquestai/deepstack
   pullPolicy: IfNotPresent
-  tag: cpu-2021.02.1
+  tag: cpu-2021.02.1@sha256:42
 
 service:
   main:

--- a/charts/stable/deluge/SCALE/ix_values.yaml
+++ b/charts/stable/deluge/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/deluge
   pullPolicy: IfNotPresent
-  tag: version-2.0.3-2201906121747ubuntu18.04.1
+  tag: version-2.0.3-2201906121747ubuntu18.04.1@sha256:42
 
 
 ##

--- a/charts/stable/deluge/values.yaml
+++ b/charts/stable/deluge/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/linuxserver/deluge
   pullPolicy: IfNotPresent
-  tag: version-2.0.3-2201906121747ubuntu18.04.1
+  tag: version-2.0.3-2201906121747ubuntu18.04.1@sha256:42
 
 service:
   main:

--- a/charts/stable/dizquetv/SCALE/ix_values.yaml
+++ b/charts/stable/dizquetv/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/dizquetv
   pullPolicy: IfNotPresent
-  tag: v1.4.3
+  tag: v1.4.3@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/dizquetv/values.yaml
+++ b/charts/stable/dizquetv/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: v1.4.3
+  tag: v1.4.3@sha256:42
 
 # -- environment variables. See more environment variables in the [dizquetv documentation](https://hub.docker.com/r/vexorian/dizquetv).
 # @default -- See below

--- a/charts/stable/duplicati/SCALE/ix_values.yaml
+++ b/charts/stable/duplicati/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/duplicati
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: latest@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/duplicati/values.yaml
+++ b/charts/stable/duplicati/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/linuxserver/duplicati
   # -- image tag
-  tag: latest
+  tag: latest@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/emby/SCALE/ix_values.yaml
+++ b/charts/stable/emby/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/emby
   pullPolicy: IfNotPresent
-  tag: v4.6.4.0
+  tag: v4.6.4.0@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/emby/values.yaml
+++ b/charts/stable/emby/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/emby
   pullPolicy: IfNotPresent
-  tag: v4.6.4.0
+  tag: v4.6.4.0@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/esphome/SCALE/ix_values.yaml
+++ b/charts/stable/esphome/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/esphome
   pullPolicy: IfNotPresent
-  tag: v2021.8.2
+  tag: v2021.8.2@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/esphome/values.yaml
+++ b/charts/stable/esphome/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/esphome
   pullPolicy: IfNotPresent
-  tag: v2021.8.2
+  tag: v2021.8.2@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/external-service/SCALE/ix_values.yaml
+++ b/charts/stable/external-service/SCALE/ix_values.yaml
@@ -8,7 +8,7 @@
 image:
   repository: ghcr.io/truecharts/bs
   pullPolicy: IfNotPresent
-  tag: v0.66.6
+  tag: v0.66.6@sha256:42
 
 # Disable Deployment
 controller:

--- a/charts/stable/external-service/values.yaml
+++ b/charts/stable/external-service/values.yaml
@@ -2,7 +2,7 @@
 image:
   repository: ghcr.io/truecharts/bs
   pullPolicy: IfNotPresent
-  tag: v0.66.6
+  tag: v0.66.6@sha256:42
 
 # Disable Deployment
 controller:

--- a/charts/stable/fireflyiii/SCALE/ix_values.yaml
+++ b/charts/stable/fireflyiii/SCALE/ix_values.yaml
@@ -7,13 +7,13 @@
 image:
   repository: fireflyiii/core
   pullPolicy: IfNotPresent
-  tag: version-5.5.12
+  tag: version-5.5.12@sha256:42
 
 
 postgresqlImage:
   repository: postgres
   pullPolicy: IfNotPresent
-  tag: 13.4-alpine
+  tag: 13.4-alpine@sha256:42
 
 initContainers:
   init-postgresdb:

--- a/charts/stable/fireflyiii/values.yaml
+++ b/charts/stable/fireflyiii/values.yaml
@@ -3,13 +3,13 @@
 image:
   repository: fireflyiii/core
   pullPolicy: IfNotPresent
-  tag: version-5.5.12
+  tag: version-5.5.12@sha256:42
 
 
 postgresqlImage:
   repository: postgres
   pullPolicy: IfNotPresent
-  tag: 13.4-alpine
+  tag: 13.4-alpine@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/flaresolverr/SCALE/ix_values.yaml
+++ b/charts/stable/flaresolverr/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/flaresolverr/flaresolverr
   pullPolicy: IfNotPresent
-  tag: v1.2.9
+  tag: v1.2.9@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/flaresolverr/values.yaml
+++ b/charts/stable/flaresolverr/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: v1.2.9
+  tag: v1.2.9@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/flood/SCALE/ix_values.yaml
+++ b/charts/stable/flood/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/flood
   pullPolicy: IfNotPresent
-  tag: v4.6.1
+  tag: v4.6.1@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/flood/values.yaml
+++ b/charts/stable/flood/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: v4.6.1
+  tag: v4.6.1@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/focalboard/SCALE/ix_values.yaml
+++ b/charts/stable/focalboard/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/focalboard
   pullPolicy: IfNotPresent
-  tag: v0.8.0
+  tag: v0.8.0@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/focalboard/values.yaml
+++ b/charts/stable/focalboard/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: v0.8.0
+  tag: v0.8.0@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/freeradius/SCALE/ix_values.yaml
+++ b/charts/stable/freeradius/SCALE/ix_values.yaml
@@ -6,7 +6,7 @@
 image:
   repository: ghcr.io/truecharts/freeradius
   pullPolicy: IfNotPresent
-  tag: v3.0.23
+  tag: v3.0.23@sha256:42
 
 # -- Probe configuration
 # -- [[ref]](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)

--- a/charts/stable/freeradius/values.yaml
+++ b/charts/stable/freeradius/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/freeradius
   pullPolicy: IfNotPresent
-  tag: v3.0.23
+  tag: v3.0.23@sha256:42
 
 service:
   main:

--- a/charts/stable/freshrss/SCALE/ix_values.yaml
+++ b/charts/stable/freshrss/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/freshrss
   pullPolicy: IfNotPresent
-  tag: version-1.18.1
+  tag: version-1.18.1@sha256:42
 
 
 ##

--- a/charts/stable/freshrss/values.yaml
+++ b/charts/stable/freshrss/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/linuxserver/freshrss
   pullPolicy: IfNotPresent
-  tag: version-1.18.1
+  tag: version-1.18.1@sha256:42
 
 service:
   main:

--- a/charts/stable/gaps/SCALE/ix_values.yaml
+++ b/charts/stable/gaps/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/gaps
   pullPolicy: IfNotPresent
-  tag: v0.8.8
+  tag: v0.8.8@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/gaps/values.yaml
+++ b/charts/stable/gaps/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/gaps
   pullPolicy: IfNotPresent
-  tag: v0.8.8
+  tag: v0.8.8@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/gonic/SCALE/ix_values.yaml
+++ b/charts/stable/gonic/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/gonic
   pullPolicy: IfNotPresent
-  tag: v0.13.1
+  tag: v0.13.1@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/gonic/values.yaml
+++ b/charts/stable/gonic/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: v0.13.1
+  tag: v0.13.1@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/grocy/SCALE/ix_values.yaml
+++ b/charts/stable/grocy/SCALE/ix_values.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: ghcr.io/linuxserver/grocy
-  tag: version-v3.1.1
+  tag: version-v3.1.1@sha256:42
   pullPolicy: IfNotPresent
 
 

--- a/charts/stable/grocy/values.yaml
+++ b/charts/stable/grocy/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/linuxserver/grocy
-  tag: version-v3.1.1
+  tag: version-v3.1.1@sha256:42
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/stable/handbrake/SCALE/ix_values.yaml
+++ b/charts/stable/handbrake/SCALE/ix_values.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: ghcr.io/truecharts/handbrake
-  tag: v1.24.1
+  tag: v1.24.1@sha256:42
   pullPolicy: IfNotPresent
 
 #All values here are set as the docker defaults.

--- a/charts/stable/handbrake/values.yaml
+++ b/charts/stable/handbrake/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/truecharts/handbrake
-  tag: v1.24.1
+  tag: v1.24.1@sha256:42
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/stable/haste-server/SCALE/ix_values.yaml
+++ b/charts/stable/haste-server/SCALE/ix_values.yaml
@@ -10,7 +10,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: latest
+  tag: latest@sha256:42
 
 
 ##

--- a/charts/stable/haste-server/values.yaml
+++ b/charts/stable/haste-server/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: latest
+  tag: latest@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/healthchecks/SCALE/ix_values.yaml
+++ b/charts/stable/healthchecks/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/healthchecks
   pullPolicy: IfNotPresent
-  tag: version-v1.22.0
+  tag: version-v1.22.0@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/healthchecks/values.yaml
+++ b/charts/stable/healthchecks/values.yaml
@@ -4,7 +4,7 @@ image:
   # -- image repository
   repository: ghcr.io/linuxserver/healthchecks
   # -- image tag
-  tag: version-v1.22.0
+  tag: version-v1.22.0@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/heimdall/SCALE/ix_values.yaml
+++ b/charts/stable/heimdall/SCALE/ix_values.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: ghcr.io/linuxserver/heimdall
-  tag: version-2.2.2
+  tag: version-2.2.2@sha256:42
   pullPolicy: IfNotPresent
 
 

--- a/charts/stable/heimdall/values.yaml
+++ b/charts/stable/heimdall/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/linuxserver/heimdall
-  tag: version-2.2.2
+  tag: version-2.2.2@sha256:42
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/stable/home-assistant/SCALE/ix_values.yaml
+++ b/charts/stable/home-assistant/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/home-assistant
   pullPolicy: IfNotPresent
-  tag: v2021.9.5
+  tag: v2021.9.5@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/home-assistant/values.yaml
+++ b/charts/stable/home-assistant/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/home-assistant
   pullPolicy: IfNotPresent
-  tag: v2021.9.5
+  tag: v2021.9.5@sha256:42
 
 env: {}
     # TZ:

--- a/charts/stable/hyperion-ng/SCALE/ix_values.yaml
+++ b/charts/stable/hyperion-ng/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: sirfragalot/hyperion.ng
   pullPolicy: IfNotPresent
-  tag: 2.0.0-alpha.10-x86_64
+  tag: 2.0.0-alpha.10-x86_64@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/hyperion-ng/values.yaml
+++ b/charts/stable/hyperion-ng/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: sirfragalot/hyperion.ng
   # -- image tag
-  tag: 2.0.0-alpha.10-x86_64
+  tag: 2.0.0-alpha.10-x86_64@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/jackett/SCALE/ix_values.yaml
+++ b/charts/stable/jackett/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/jackett
   pullPolicy: IfNotPresent
-  tag: v0.18.686
+  tag: v0.18.686@sha256:42
 
 probes:
   liveness:

--- a/charts/stable/jackett/values.yaml
+++ b/charts/stable/jackett/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/jackett
   pullPolicy: IfNotPresent
-  tag: v0.18.686@sha256:42
+  tag: v0.18.686@sha256:42@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/jdownloader2/SCALE/ix_values.yaml
+++ b/charts/stable/jdownloader2/SCALE/ix_values.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: ghcr.io/truecharts/jdownloader-2
-  tag: v1.7.1
+  tag: v1.7.1@sha256:42
   pullPolicy: IfNotPresent
 
 #All values here are set as the docker defaults.

--- a/charts/stable/jdownloader2/values.yaml
+++ b/charts/stable/jdownloader2/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/jdownloader-2
   pullPolicy: IfNotPresent
-  tag: v1.7.1
+  tag: v1.7.1@sha256:42
 
 service:
   main:

--- a/charts/stable/jellyfin/SCALE/ix_values.yaml
+++ b/charts/stable/jellyfin/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/jellyfin
   pullPolicy: IfNotPresent
-  tag: v10.7.7
+  tag: v10.7.7@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/jellyfin/values.yaml
+++ b/charts/stable/jellyfin/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/jellyfin
   pullPolicy: IfNotPresent
-  tag: v10.7.7
+  tag: v10.7.7@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/k8s-gateway/SCALE/ix_values.yaml
+++ b/charts/stable/k8s-gateway/SCALE/ix_values.yaml
@@ -9,7 +9,7 @@
 image:
   repository: quay.io/oriedge/k8s_gateway
   pullPolicy: IfNotPresent
-  tag: v0.1.8
+  tag: v0.1.8@sha256:42
 
 args: ["-conf", "/etc/coredns/Corefile"]
 

--- a/charts/stable/k8s-gateway/values.yaml
+++ b/charts/stable/k8s-gateway/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: quay.io/oriedge/k8s_gateway
   pullPolicy: IfNotPresent
-  tag: v0.1.8
+  tag: v0.1.8@sha256:42
 
 args: ["-conf", "/etc/coredns/Corefile"]
 

--- a/charts/stable/kms/SCALE/ix_values.yaml
+++ b/charts/stable/kms/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: pykmsorg/py-kms
   pullPolicy: IfNotPresent
-  tag: minimal
+  tag: minimal@sha256:42
 
 
 ##

--- a/charts/stable/kms/values.yaml
+++ b/charts/stable/kms/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: pykmsorg/py-kms
   pullPolicy: IfNotPresent
-  tag: minimal
+  tag: minimal@sha256:42
 
 service:
   main:

--- a/charts/stable/komga/SCALE/ix_values.yaml
+++ b/charts/stable/komga/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/komga
   pullPolicy: IfNotPresent
-  tag: v0.125.3
+  tag: v0.125.3@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/komga/values.yaml
+++ b/charts/stable/komga/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/truecharts/komga
   # -- image tag
-  tag: v0.125.3
+  tag: v0.125.3@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/lazylibrarian/SCALE/ix_values.yaml
+++ b/charts/stable/lazylibrarian/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/lazylibrarian
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: latest@sha256:42
 
 
 ##

--- a/charts/stable/lazylibrarian/values.yaml
+++ b/charts/stable/lazylibrarian/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/linuxserver/lazylibrarian
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: latest@sha256:42
 
 service:
   main:

--- a/charts/stable/librespeed/SCALE/ix_values.yaml
+++ b/charts/stable/librespeed/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/librespeed
   pullPolicy: IfNotPresent
-  tag: version-5.2.4
+  tag: version-5.2.4@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/librespeed/values.yaml
+++ b/charts/stable/librespeed/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/linuxserver/librespeed
   # -- image tag
-  tag: version-5.2.4
+  tag: version-5.2.4@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/lidarr/SCALE/ix_values.yaml
+++ b/charts/stable/lidarr/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/lidarr
   pullPolicy: IfNotPresent
-  tag: v1.0.0.2255
+  tag: v1.0.0.2255@sha256:42
 
 probes:
     liveness:

--- a/charts/stable/lidarr/values.yaml
+++ b/charts/stable/lidarr/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/lidarr
   pullPolicy: IfNotPresent
-  tag: v1.0.0.2255
+  tag: v1.0.0.2255@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/littlelink/SCALE/ix_values.yaml
+++ b/charts/stable/littlelink/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/techno-tim/littlelink-server
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: latest@sha256:42
 
 envFrom:
   - configMapRef:

--- a/charts/stable/littlelink/values.yaml
+++ b/charts/stable/littlelink/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/techno-tim/littlelink-server
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: latest@sha256:42
 
 
 service:

--- a/charts/stable/lychee/SCALE/ix_values.yaml
+++ b/charts/stable/lychee/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/lychee-laravel
   pullPolicy: IfNotPresent
-  tag: v4.3.4
+  tag: v4.3.4@sha256:42
 
 
 ##

--- a/charts/stable/lychee/values.yaml
+++ b/charts/stable/lychee/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/lychee-laravel
   pullPolicy: IfNotPresent
-  tag: v4.3.4
+  tag: v4.3.4@sha256:42
 
 service:
   main:

--- a/charts/stable/mealie/SCALE/ix_values.yaml
+++ b/charts/stable/mealie/SCALE/ix_values.yaml
@@ -8,7 +8,7 @@ image:
   # -- image repository
   repository: ghcr.io/truecharts/mealie
   # -- image tag
-  tag: v0.5.2
+  tag: v0.5.2@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/mealie/values.yaml
+++ b/charts/stable/mealie/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/truecharts/mealie
   # -- image tag
-  tag: v0.5.2
+  tag: v0.5.2@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/mosquitto/SCALE/ix_values.yaml
+++ b/charts/stable/mosquitto/SCALE/ix_values.yaml
@@ -8,7 +8,7 @@ image:
   # -- image repository
   repository: eclipse-mosquitto
   # -- image tag
-  tag: 2.0.12
+  tag: 2.0.12@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/mosquitto/values.yaml
+++ b/charts/stable/mosquitto/values.yaml
@@ -4,7 +4,7 @@ image:
   # -- image repository
   repository: eclipse-mosquitto
   # -- image tag
-  tag: 2.0.12
+  tag: 2.0.12@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/mylar/SCALE/ix_values.yaml
+++ b/charts/stable/mylar/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/mylar3
   pullPolicy: IfNotPresent
-  tag: version-v0.5.3
+  tag: version-v0.5.3@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/mylar/values.yaml
+++ b/charts/stable/mylar/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/linuxserver/mylar3
   # -- image tag
-  tag: version-v0.5.3
+  tag: version-v0.5.3@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/navidrome/SCALE/ix_values.yaml
+++ b/charts/stable/navidrome/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/navidrome
   pullPolicy: IfNotPresent
-  tag: v0.45.1
+  tag: v0.45.1@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/navidrome/values.yaml
+++ b/charts/stable/navidrome/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/navidrome
   pullPolicy: IfNotPresent
-  tag: v0.45.1
+  tag: v0.45.1@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/nextcloud/SCALE/ix_values.yaml
+++ b/charts/stable/nextcloud/SCALE/ix_values.yaml
@@ -7,12 +7,12 @@
 image:
   repository: nextcloud
   pullPolicy: IfNotPresent
-  tag: 22.1.1
+  tag: 22.1.1@sha256:42
 
 postgresqlImage:
   repository: postgres
   pullPolicy: IfNotPresent
-  tag: 13.4-alpine
+  tag: 13.4-alpine@sha256:42
 
 strategy:
   type: Recreate

--- a/charts/stable/nextcloud/values.yaml
+++ b/charts/stable/nextcloud/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: nextcloud
   pullPolicy: IfNotPresent
-  tag: 22.1.1
+  tag: 22.1.1@sha256:42
 
 podSecurityContext:
   runAsUser: 0
@@ -15,7 +15,7 @@ podSecurityContext:
 postgresqlImage:
   repository: postgres
   pullPolicy: IfNotPresent
-  tag: "13.1"
+  tag: "13.1"@sha256:42
 
 service:
   main:

--- a/charts/stable/node-red/SCALE/ix_values.yaml
+++ b/charts/stable/node-red/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/node-red
   pullPolicy: IfNotPresent
-  tag: v2.0.6
+  tag: v2.0.6@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/node-red/values.yaml
+++ b/charts/stable/node-red/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/node-red
   pullPolicy: IfNotPresent
-  tag: v2.0.6
+  tag: v2.0.6@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/nullserv/SCALE/ix_values.yaml
+++ b/charts/stable/nullserv/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/nullserv
   pullPolicy: IfNotPresent
-  tag: v1.3.0
+  tag: v1.3.0@sha256:42
 
 # -- Configures the probes for the main Pod.
 # @default -- See values.yaml

--- a/charts/stable/nullserv/values.yaml
+++ b/charts/stable/nullserv/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- image repository
   repository: ghcr.io/k8s-at-home/nullserv
   # -- image tag
-  tag: v1.3.0
+  tag: v1.3.0@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/nzbget/SCALE/ix_values.yaml
+++ b/charts/stable/nzbget/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/nzbget
   pullPolicy: IfNotPresent
-  tag: v21.1
+  tag: v21.1@sha256:42
 
 probes:
   liveness:

--- a/charts/stable/nzbget/values.yaml
+++ b/charts/stable/nzbget/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/nzbget
   pullPolicy: IfNotPresent
-  tag: v21.1
+  tag: v21.1@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/nzbhydra/SCALE/ix_values.yaml
+++ b/charts/stable/nzbhydra/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/nzbhydra2
   pullPolicy: IfNotPresent
-  tag: v3.15.2
+  tag: v3.15.2@sha256:42
 
 probes:
   liveness:

--- a/charts/stable/nzbhydra/values.yaml
+++ b/charts/stable/nzbhydra/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/nzbhydra2
   pullPolicy: IfNotPresent
-  tag: v3.15.2
+  tag: v3.15.2@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/octoprint/SCALE/ix_values.yaml
+++ b/charts/stable/octoprint/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/octoprint
   pullPolicy: IfNotPresent
-  tag: v1.6.1
+  tag: v1.6.1@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/octoprint/values.yaml
+++ b/charts/stable/octoprint/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/truecharts/octoprint
   # -- image tag
-  tag: v1.6.1
+  tag: v1.6.1@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/omada-controller/SCALE/ix_values.yaml
+++ b/charts/stable/omada-controller/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: mbentley/omada-controller
   pullPolicy: IfNotPresent
-  tag: '4.4'
+  tag: '4.4'@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/omada-controller/values.yaml
+++ b/charts/stable/omada-controller/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: mbentley/omada-controller
   # -- image tag
-  tag: '4.4'
+  tag: '4.4'@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/ombi/SCALE/ix_values.yaml
+++ b/charts/stable/ombi/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/ombi
   pullPolicy: IfNotPresent
-  tag: v4.0.1475
+  tag: v4.0.1475@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/ombi/values.yaml
+++ b/charts/stable/ombi/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/ombi
   pullPolicy: IfNotPresent
-  tag: v4.0.1475
+  tag: v4.0.1475@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/openldap/SCALE/ix_values.yaml
+++ b/charts/stable/openldap/SCALE/ix_values.yaml
@@ -6,7 +6,7 @@
 image:
   repository: ghcr.io/truecharts/openldap
   pullPolicy: IfNotPresent
-  tag: v1.5.0
+  tag: v1.5.0@sha256:42
 
 controller:
   # -- Set the controller type.

--- a/charts/stable/openldap/values.yaml
+++ b/charts/stable/openldap/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/openldap
   pullPolicy: IfNotPresent
-  tag: v1.5.0
+  tag: v1.5.0@sha256:42
 
 controller:
   # -- Set the controller type.

--- a/charts/stable/organizr/SCALE/ix_values.yaml
+++ b/charts/stable/organizr/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: organizr/organizr
   pullPolicy: Always
-  tag: latest
+  tag: latest@sha256:42
 
 
 ##

--- a/charts/stable/organizr/values.yaml
+++ b/charts/stable/organizr/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: organizr/organizr
   pullPolicy: Always
-  tag: latest
+  tag: latest@sha256:42
 
 service:
   main:

--- a/charts/stable/overseerr/SCALE/ix_values.yaml
+++ b/charts/stable/overseerr/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/sct/overseerr
   pullPolicy: IfNotPresent
-  tag: 1.25.0
+  tag: 1.25.0@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/overseerr/values.yaml
+++ b/charts/stable/overseerr/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/sct/overseerr
   # -- image tag
-  tag: 1.25.0
+  tag: 1.25.0@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/owncast/SCALE/ix_values.yaml
+++ b/charts/stable/owncast/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/owncast
   pullPolicy: IfNotPresent
-  tag: v0.0.8
+  tag: v0.0.8@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/owncast/values.yaml
+++ b/charts/stable/owncast/values.yaml
@@ -9,7 +9,7 @@ image:
 # -- image repository
   repository: ghcr.io/truecharts/owncast
   # -- image tag
-  tag: v0.0.8
+  tag: v0.0.8@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/owncloud-ocis/SCALE/ix_values.yaml
+++ b/charts/stable/owncloud-ocis/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/ocis
   pullPolicy: IfNotPresent
-  tag: v1.11.0
+  tag: v1.11.0@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/owncloud-ocis/values.yaml
+++ b/charts/stable/owncloud-ocis/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/truecharts/ocis
   # -- image tag
-  tag: v1.11.0
+  tag: v1.11.0@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/pgadmin/SCALE/ix_values.yaml
+++ b/charts/stable/pgadmin/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: dpage/pgadmin4
   pullPolicy: IfNotPresent
-  tag: "5.6"
+  tag: "5.6"@sha256:42
 
 
 ##

--- a/charts/stable/pgadmin/values.yaml
+++ b/charts/stable/pgadmin/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: dpage/pgadmin4
   pullPolicy: IfNotPresent
-  tag: "5.6"
+  tag: "5.6"@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/photoprism/SCALE/ix_values.yaml
+++ b/charts/stable/photoprism/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: photoprism/photoprism
   pullPolicy: IfNotPresent
-  tag: "20210523"
+  tag: "20210523"@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/photoprism/values.yaml
+++ b/charts/stable/photoprism/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: photoprism/photoprism
   # -- image tag
-  tag: "20210523"
+  tag: "20210523"@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/phpldapadmin/SCALE/ix_values.yaml
+++ b/charts/stable/phpldapadmin/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/phpldapadmin
   pullPolicy: IfNotPresent
-  tag: v0.9.0
+  tag: v0.9.0@sha256:42
 
 
 ##

--- a/charts/stable/phpldapadmin/values.yaml
+++ b/charts/stable/phpldapadmin/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/phpldapadmin
   pullPolicy: IfNotPresent
-  tag: v0.9.0
+  tag: v0.9.0@sha256:42
 
 
 service:

--- a/charts/stable/piaware/SCALE/ix_values.yaml
+++ b/charts/stable/piaware/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/piaware
   pullPolicy: IfNotPresent
-  tag: v6.1
+  tag: v6.1@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/piaware/values.yaml
+++ b/charts/stable/piaware/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/truecharts/piaware
   # -- image tag
-  tag: v6.1
+  tag: v6.1@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/pihole/SCALE/ix_values.yaml
+++ b/charts/stable/pihole/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/pihole
   pullPolicy: IfNotPresent
-  tag: v5.8.1
+  tag: v5.8.1@sha256:42
 
 envFrom:
   - configMapRef:

--- a/charts/stable/pihole/values.yaml
+++ b/charts/stable/pihole/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/pihole
   pullPolicy: IfNotPresent
-  tag: v5.8.1
+  tag: v5.8.1@sha256:42
 
 envFrom:
   - configMapRef:

--- a/charts/stable/plex/SCALE/ix_values.yaml
+++ b/charts/stable/plex/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/plex
   pullPolicy: IfNotPresent
-  tag: v1.24.1.4931-1a38e63c6
+  tag: v1.24.1.4931-1a38e63c6@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/plex/values.yaml
+++ b/charts/stable/plex/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/plex
   pullPolicy: IfNotPresent
-  tag: v1.24.1.4931-1a38e63c6
+  tag: v1.24.1.4931-1a38e63c6@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/podgrab/SCALE/ix_values.yaml
+++ b/charts/stable/podgrab/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/podgrab
   pullPolicy: Always
-  tag: v1.0.0
+  tag: v1.0.0@sha256:42
 
 
 probes:

--- a/charts/stable/podgrab/values.yaml
+++ b/charts/stable/podgrab/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/podgrab
   pullPolicy: Always
-  tag: v1.0.0
+  tag: v1.0.0@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/postgresql/SCALE/ix_values.yaml
+++ b/charts/stable/postgresql/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: postgres
   pullPolicy: IfNotPresent
-  tag: "13.4"
+  tag: "13.4"@sha256:42
 
 
 envValueFrom:

--- a/charts/stable/postgresql/values.yaml
+++ b/charts/stable/postgresql/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: postgres
   pullPolicy: IfNotPresent
-  tag: "13.4"
+  tag: "13.4"@sha256:42
 
 
 service:

--- a/charts/stable/pretend-youre-xyzzy/SCALE/ix_values.yaml
+++ b/charts/stable/pretend-youre-xyzzy/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: emcniece/dockeryourxyzzy
   pullPolicy: IfNotPresent
-  tag: "4"
+  tag: "4"@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/pretend-youre-xyzzy/values.yaml
+++ b/charts/stable/pretend-youre-xyzzy/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: emcniece/dockeryourxyzzy
   # -- image tag
-  tag: "4"
+  tag: "4"@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/protonmail-bridge/SCALE/ix_values.yaml
+++ b/charts/stable/protonmail-bridge/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: shenxn/protonmail-bridge
   pullPolicy: IfNotPresent
-  tag: 1.8.7-1
+  tag: 1.8.7-1@sha256:42
 
 service:
   main:

--- a/charts/stable/protonmail-bridge/values.yaml
+++ b/charts/stable/protonmail-bridge/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: shenxn/protonmail-bridge
   # -- image tag
-  tag: 1.8.7-1
+  tag: 1.8.7-1@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/prowlarr/SCALE/ix_values.yaml
+++ b/charts/stable/prowlarr/SCALE/ix_values.yaml
@@ -8,7 +8,7 @@ image:
   # -- image repository
   repository: ghcr.io/k8s-at-home/prowlarr
   # -- image tag
-  tag: v0.1.1.919
+  tag: v0.1.1.919@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/prowlarr/values.yaml
+++ b/charts/stable/prowlarr/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/k8s-at-home/prowlarr
   # -- image tag
-  tag: v0.1.1.919
+  tag: v0.1.1.919@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/pyload/SCALE/ix_values.yaml
+++ b/charts/stable/pyload/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/pyload
   pullPolicy: IfNotPresent
-  tag: version-5de90278
+  tag: version-5de90278@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/pyload/values.yaml
+++ b/charts/stable/pyload/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/linuxserver/pyload
   # -- image tag
-  tag: version-5de90278
+  tag: version-5de90278@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/qbittorrent/SCALE/ix_values.yaml
+++ b/charts/stable/qbittorrent/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/qbittorrent
   pullPolicy: IfNotPresent
-  tag: v4.3.7
+  tag: v4.3.7@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/qbittorrent/values.yaml
+++ b/charts/stable/qbittorrent/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/qbittorrent
   pullPolicy: IfNotPresent
-  tag: v4.3.7
+  tag: v4.3.7@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/radarr/SCALE/ix_values.yaml
+++ b/charts/stable/radarr/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/radarr
   pullPolicy: IfNotPresent
-  tag: v3.2.2.5080
+  tag: v3.2.2.5080@sha256:42
 
 probes:
   liveness:

--- a/charts/stable/radarr/values.yaml
+++ b/charts/stable/radarr/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/radarr
   pullPolicy: IfNotPresent
-  tag: v3.2.2.5080
+  tag: v3.2.2.5080@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/readarr/SCALE/ix_values.yaml
+++ b/charts/stable/readarr/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/readarr
   pullPolicy: IfNotPresent
-  tag: v0.1.0.963
+  tag: v0.1.0.963@sha256:42
 
 probes:
     liveness:

--- a/charts/stable/readarr/values.yaml
+++ b/charts/stable/readarr/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/readarr
   pullPolicy: IfNotPresent
-  tag: v0.1.0.963
+  tag: v0.1.0.963@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/reg/SCALE/ix_values.yaml
+++ b/charts/stable/reg/SCALE/ix_values.yaml
@@ -10,7 +10,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: v0.16.1
+  tag: v0.16.1@sha256:42
 
 
 ##

--- a/charts/stable/reg/values.yaml
+++ b/charts/stable/reg/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: v0.16.1
+  tag: v0.16.1@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/resilio-sync/SCALE/ix_values.yaml
+++ b/charts/stable/resilio-sync/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/resilio-sync
   pullPolicy: IfNotPresent
-  tag: version-2.7.2.1375
+  tag: version-2.7.2.1375@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/resilio-sync/values.yaml
+++ b/charts/stable/resilio-sync/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/linuxserver/resilio-sync
   # -- image tag
-  tag: version-2.7.2.1375
+  tag: version-2.7.2.1375@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/sabnzbd/SCALE/ix_values.yaml
+++ b/charts/stable/sabnzbd/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/sabnzbd
   pullPolicy: IfNotPresent
-  tag: v3.3.1
+  tag: v3.3.1@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/sabnzbd/values.yaml
+++ b/charts/stable/sabnzbd/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/sabnzbd
   pullPolicy: IfNotPresent
-  tag: v3.3.1
+  tag: v3.3.1@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/ser2sock/SCALE/ix_values.yaml
+++ b/charts/stable/ser2sock/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: tenstartups/ser2sock
   pullPolicy: IfNotPresent
-  tag: latest
+  tag: latest@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/ser2sock/values.yaml
+++ b/charts/stable/ser2sock/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: tenstartups/ser2sock
   # -- image tag
-  tag: latest
+  tag: latest@sha256:42
   # -- image pull policy
   pullPolicy: Always
 

--- a/charts/stable/sonarr/SCALE/ix_values.yaml
+++ b/charts/stable/sonarr/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/sonarr
   pullPolicy: IfNotPresent
-  tag: v3.0.6.1265
+  tag: v3.0.6.1265@sha256:42
 
 probes:
   liveness:

--- a/charts/stable/sonarr/values.yaml
+++ b/charts/stable/sonarr/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/sonarr
   pullPolicy: IfNotPresent
-  tag: v3.0.6.1265
+  tag: v3.0.6.1265@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/stash/SCALE/ix_values.yaml
+++ b/charts/stable/stash/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/stash
   pullPolicy: IfNotPresent
-  tag: v0.9.0
+  tag: v0.9.0@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/stash/values.yaml
+++ b/charts/stable/stash/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/truecharts/stash
   # -- image tag
-  tag: v0.9.0
+  tag: v0.9.0@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/syncthing/SCALE/ix_values.yaml
+++ b/charts/stable/syncthing/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/syncthing
   pullPolicy: IfNotPresent
-  tag: v1.18
+  tag: v1.18@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/syncthing/values.yaml
+++ b/charts/stable/syncthing/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/syncthing
   pullPolicy: IfNotPresent
-  tag: v1.18.2
+  tag: v1.18.2@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/tautulli/SCALE/ix_values.yaml
+++ b/charts/stable/tautulli/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/tautulli
   pullPolicy: IfNotPresent
-  tag: v2.7.6
+  tag: v2.7.6@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/tautulli/values.yaml
+++ b/charts/stable/tautulli/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/tautulli
   pullPolicy: IfNotPresent
-  tag: v2.7.6
+  tag: v2.7.6@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/thelounge/SCALE/ix_values.yaml
+++ b/charts/stable/thelounge/SCALE/ix_values.yaml
@@ -10,7 +10,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: v4.2.0
+  tag: v4.2.0@sha256:42
 
 
 ##

--- a/charts/stable/thelounge/values.yaml
+++ b/charts/stable/thelounge/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- image pull policy
   pullPolicy: IfNotPresent
   # -- image tag
-  tag: v4.2.0
+  tag: v4.2.0@sha256:42
 
 # -- environment variables. See [image docs](https://hub.docker.com/r/thelounge/thelounge/) for more details.
 # @default -- See below

--- a/charts/stable/traefik/SCALE/ix_values.yaml
+++ b/charts/stable/traefik/SCALE/ix_values.yaml
@@ -2,7 +2,7 @@
 image:
   repository: traefik
   # defaults to appVersion
-  tag: v2.5.2
+  tag: v2.5.2@sha256:42
   pullPolicy: IfNotPresent
 
 # Create an IngressRoute for the dashboard

--- a/charts/stable/traefik/values.yaml
+++ b/charts/stable/traefik/values.yaml
@@ -2,7 +2,7 @@
 image:
   repository: traefik
   # defaults to appVersion
-  tag: v2.5.2
+  tag: v2.5.2@sha256:42
   pullPolicy: IfNotPresent
 
 # -- Set the container security context

--- a/charts/stable/transmission/SCALE/ix_values.yaml
+++ b/charts/stable/transmission/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/transmission
   pullPolicy: IfNotPresent
-  tag: v3.00
+  tag: v3.00@sha256:42
 
 transmissionFixedConfig:
   bind-address-ipv4: "0.0.0.0"

--- a/charts/stable/transmission/values.yaml
+++ b/charts/stable/transmission/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/k8s-at-home/transmission
   pullPolicy: IfNotPresent
-  tag: v3.00
+  tag: v3.00@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/truecommand/SCALE/ix_values.yaml
+++ b/charts/stable/truecommand/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/truecommand
   pullPolicy: IfNotPresent
-  tag: v2.0.2
+  tag: v2.0.2@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/truecommand/values.yaml
+++ b/charts/stable/truecommand/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/truecommand
   pullPolicy: IfNotPresent
-  tag: v2.0.2
+  tag: v2.0.2@sha256:42
 
 service:
   main:

--- a/charts/stable/tvheadend/SCALE/ix_values.yaml
+++ b/charts/stable/tvheadend/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/linuxserver/tvheadend
   pullPolicy: IfNotPresent
-  tag: version-63784405
+  tag: version-63784405@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/tvheadend/values.yaml
+++ b/charts/stable/tvheadend/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/linuxserver/tvheadend
   pullPolicy: IfNotPresent
-  tag: version-63784405
+  tag: version-63784405@sha256:42
 
 # See https://github.com/linuxserver/docker-tvheadend#parameters
 env: {}

--- a/charts/stable/unifi/SCALE/ix_values.yaml
+++ b/charts/stable/unifi/SCALE/ix_values.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: ghcr.io/truecharts/unifi
-  tag: v6.2.26
+  tag: v6.2.26@sha256:42
   pullPolicy: IfNotPresent
 
 envTpl:

--- a/charts/stable/unifi/values.yaml
+++ b/charts/stable/unifi/values.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: ghcr.io/truecharts/unifi
-  tag: v6.2.26
+  tag: v6.2.26@sha256:42
   pullPolicy: IfNotPresent
 
 envTpl:

--- a/charts/stable/unpackerr/SCALE/ix_values.yaml
+++ b/charts/stable/unpackerr/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/unpackerr
   pullPolicy: IfNotPresent
-  tag: v0.9.8
+  tag: v0.9.8@sha256:42
 
 service:
   main:

--- a/charts/stable/unpackerr/values.yaml
+++ b/charts/stable/unpackerr/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/unpackerr
   pullPolicy: IfNotPresent
-  tag: v0.9.8
+  tag: v0.9.8@sha256:42
 
 securityContext:
   privileged: false

--- a/charts/stable/vaultwarden/SCALE/ix_values.yaml
+++ b/charts/stable/vaultwarden/SCALE/ix_values.yaml
@@ -7,12 +7,12 @@
 image:
   repository: ghcr.io/truecharts/vaultwarden
   pullPolicy: IfNotPresent
-  tag: v1.22.2
+  tag: v1.22.2@sha256:42
 
 postgresqlImage:
   repository: postgres
   pullPolicy: IfNotPresent
-  tag: 13.4-alpine
+  tag: 13.4-alpine@sha256:42
 
 
 envTpl:

--- a/charts/stable/vaultwarden/values.yaml
+++ b/charts/stable/vaultwarden/values.yaml
@@ -3,7 +3,7 @@
 image:
   repository: ghcr.io/truecharts/vaultwarden
   pullPolicy: IfNotPresent
-  tag: v1.22.2
+  tag: v1.22.2@sha256:42
 
 securityContext:
   privileged: false
@@ -21,7 +21,7 @@ podSecurityContext:
 postgresqlImage:
   repository: postgres
   pullPolicy: IfNotPresent
-  tag: 13.4-alpine
+  tag: 13.4-alpine@sha256:42
 
 
 service:

--- a/charts/stable/xteve/SCALE/ix_values.yaml
+++ b/charts/stable/xteve/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/k8s-at-home/xteve
   pullPolicy: IfNotPresent
-  tag: v2.2.0.200
+  tag: v2.2.0.200@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/charts/stable/xteve/values.yaml
+++ b/charts/stable/xteve/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- image repository
   repository: ghcr.io/k8s-at-home/xteve
   # -- image tag
-  tag: v2.2.0.200
+  tag: v2.2.0.200@sha256:42
   # -- image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/stable/zwavejs2mqtt/SCALE/ix_values.yaml
+++ b/charts/stable/zwavejs2mqtt/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: ghcr.io/truecharts/zwavejs2mqtt
   pullPolicy: IfNotPresent
-  tag: v5.5.4
+  tag: v5.5.4@sha256:42
 
 probes:
   liveness:

--- a/charts/stable/zwavejs2mqtt/values.yaml
+++ b/charts/stable/zwavejs2mqtt/values.yaml
@@ -5,7 +5,7 @@
 image:
   repository: ghcr.io/truecharts/zwavejs2mqtt
   pullPolicy: IfNotPresent
-  tag: v5.5.4
+  tag: v5.5.4@sha256:42
 
 securityContext:
   privileged: false

--- a/templates/app/SCALE/ix_values.yaml
+++ b/templates/app/SCALE/ix_values.yaml
@@ -7,7 +7,7 @@
 image:
   repository: PLACEHOLDERREPO
   pullPolicy: IfNotPresent
-  tag: PLACEHOLDERTAG
+  tag: PLACEHOLDERTAG@sha256:42
 
 ##
 # Most other defaults are set in questions.yaml

--- a/templates/app/values.yaml
+++ b/templates/app/values.yaml
@@ -8,7 +8,7 @@
 image:
   repository: ${CHARTNAME}/${CHARTNAME}
   pullPolicy: IfNotPresent
-  tag: 1.0.0
+  tag: 1.0.0@sha256:42
 
 securityContext:
   privileged: false

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -124,6 +124,7 @@ sync_tag() {
     local chartversion="$4"
     echo "Attempting to sync primary tag with appversion for: ${chartname}"
     local tag="$(cat ${chart}/values.yaml | grep '^  tag: ' | awk -F" " '{ print $2 }' | head -1)"
+    tag="${tag%%@sha256:}
     tag="${tag:-auto}"
     tag="${tag#*release-}"
     tag="${tag#*version-}"


### PR DESCRIPTION
**Description**
Digest pinning means we can ensure the container we add to a chart is always the same when pulled.
It also means we can force users to update to a newer container using the same tag, for example when updates to the base-layer (OS) get pushed by the container creator without pushing a new tag.

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

This PR requires a run of Renovate afterwards to ensure the digests are actually generated.

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
