### PR TITLE
fix: make sure autopermissions sets the group owner correctly

### DIFF
--- a/charts/library/common-test/Chart.yaml
+++ b/charts/library/common-test/Chart.yaml
@@ -22,4 +22,4 @@ name: common-test
 sources:
 - https://github.com/truecharts/apps/tree/master/charts/library/common-test
 type: application
-version: 3.1.1
+version: 3.1.2

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -12,10 +12,7 @@ maintainers:
 - email: info@truecharts.org
   name: TrueCharts
   url: truecharts.org
-- email: kjeld@schouten-lebbing.nl
-  name: Ornias1993
-  url: truecharts.org
 name: common
 sources: null
 type: library
-version: 7.0.13
+version: 7.0.14

--- a/charts/library/common/templates/lib/controller/_autopermissions.yaml
+++ b/charts/library/common/templates/lib/controller/_autopermissions.yaml
@@ -27,7 +27,7 @@ before chart installation.
   command:
     - "/bin/sh"
     - "-c"
-    - "echo 'Automatically correcting permissions...';{{ range $_, $hpm := $hostPathMounts }}chown -R {{ $group }} {{ $hpm.mountPath | squote }}; chmod -R g+w {{ $hpm.mountPath | squote }};{{ end }}"
+    - "echo 'Automatically correcting permissions...';{{ range $_, $hpm := $hostPathMounts }}chown -R :{{ $group }} {{ $hpm.mountPath | squote }}; chmod -R g+w {{ $hpm.mountPath | squote }};{{ end }}"
   volumeMounts:
     {{- range $name, $hpm := $hostPathMounts }}
     - name: {{ $name }}

--- a/charts/library/common/tests/persistentvolumeclaim_test.go
+++ b/charts/library/common/tests/persistentvolumeclaim_test.go
@@ -80,8 +80,8 @@ func (suite *PersistenceVolumeClaimTestSuite) TestMetaData() {
         "app.kubernetes.io/instance":   "common-test",
         "app.kubernetes.io/managed-by": "Helm",
         "app.kubernetes.io/name":       "common-test",
-        "app.kubernetes.io/version":"none",
-        "helm.sh/chart":                "common-test-3.1.1",
+        "app.kubernetes.io/version":"latest",
+        "helm.sh/chart":                "common-test-3.1.2",
     }
 
     tests := map[string]struct {

--- a/charts/library/common/tests/persistentvolumeclaim_test.go
+++ b/charts/library/common/tests/persistentvolumeclaim_test.go
@@ -81,7 +81,7 @@ func (suite *PersistenceVolumeClaimTestSuite) TestMetaData() {
         "app.kubernetes.io/managed-by": "Helm",
         "app.kubernetes.io/name":       "common-test",
         "app.kubernetes.io/version":"none",
-        "helm.sh/chart":                "common-test-3.1.0",
+        "helm.sh/chart":                "common-test-3.1.1",
     }
 
     tests := map[string]struct {


### PR DESCRIPTION
**Description**
Due to a typo the permisisons script did not set the group, but set the user-owning the share instead.
This is (ofc) wrong.

Also fixes a small bug in which the test wasn't ran.

Fixes: #993

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
