### PR TITLE
Fix remaining VPN addon issues

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.0.0
+version: 8.0.1

--- a/charts/library/common/templates/addons/vpn/openvpn/_container.tpl
+++ b/charts/library/common/templates/addons/vpn/openvpn/_container.tpl
@@ -6,6 +6,8 @@ name: openvpn
 image: "{{ .Values.openvpnImage.repository }}:{{ .Values.openvpnImage.tag }}"
 imagePullPolicy: {{ .Values.openvpnImage.pullPolicy }}
 securityContext:
+  runAsUser: 0
+  runAsGroup: 0
   capabilities:
     add:
       - NET_ADMIN
@@ -28,6 +30,28 @@ env:
     value: {{ $v | quote }}
 {{- end }}
 {{- end }}
+
+{{- if .Values.addons.vpn.killSwitch }}
+  - name: FIREWALL
+    value: "ON"
+  - name: ROUTE_1
+    value: "172.16.0.0/12"
+  {{- range $index, $value := .Values.addons.vpn.excludedNetworks_IPv4 }}
+  - name: ROUTE_{{ add $index 2 }}
+    value: {{ $value | quote }}
+  {{- end}}
+{{- if .Values.addons.vpn.excludedNetworks_IPv6 }}
+  {{- $excludednetworksv6 := ""}}
+  {{- range .Values.addons.vpn.excludedNetworks_IPv4 }}
+    {{- $excludednetworksv6 =  ( printf "%v;%v" $excludednetworksv6 . ) }}
+  {{- end}}
+  {{- range $index, $value := .Values.addons.vpn.excludedNetworks_IPv6 }}
+  - name: ROUTE6_{{ add $index 1 }}
+    value: {{ $value | quote }}
+  {{- end}}
+{{- end }}
+{{- end }}
+
 {{- if or .Values.addons.vpn.openvpn.auth }}
 envFrom:
   - secretRef:

--- a/charts/library/common/templates/addons/vpn/openvpn/_secret.tpl
+++ b/charts/library/common/templates/addons/vpn/openvpn/_secret.tpl
@@ -2,7 +2,6 @@
 The OpenVPN credentials secrets to be included.
 */}}
 {{- define "common.addon.openvpn.secret" -}}
-{{- with .Values.addons.vpn.openvpn.auth }}
 ---
 apiVersion: v1
 kind: Secret
@@ -11,6 +10,11 @@ metadata:
   labels:
   {{- include "common.labels" $ | nindent 4 }}
 data:
-  VPN_AUTH: {{ . | b64enc }}
-{{- end -}}
+  {{- $vpnauth := "" }}
+  {{- if .Values.addons.vpn.openvpn.username }}
+    {{- $vpnauth = ( printf "%v;%v" .Values.addons.vpn.openvpn.username .Values.addons.vpn.openvpn.password ) }}
+  {{- else }}
+    {{- $vpnauth = .Values.addons.vpn.openvpn.password }}
+  {{- end }}
+  VPN_AUTH: {{ $vpnauth | b64enc }}
 {{- end -}}

--- a/charts/library/common/templates/addons/vpn/wireguard/_container.tpl
+++ b/charts/library/common/templates/addons/vpn/wireguard/_container.tpl
@@ -34,16 +34,22 @@ env:
 {{- end }}
 {{- end }}
 
-{{- if .Values.addons.vpn.wireguard.KILLSWITCH }}
+{{- if .Values.addons.vpn.killSwitch }}
   - name: KILLSWITCH
     value: "true"
-{{- if .Values.addons.vpn.wireguard.KILLSWITCH_EXCLUDEDNETWORKS_IPV4 }}
+  {{- $excludednetworksv4 := "172.16.0.0/12"}}
+  {{- range .Values.addons.vpn.excludedNetworks_IPv4 }}
+    {{- $excludednetworksv4 =  ( printf "%v;%v" $excludednetworksv4 . ) }}
+  {{- end}}
   - name: KILLSWITCH_EXCLUDEDNETWORKS_IPV4
-    value: {{ .Values.addons.vpn.wireguard.KILLSWITCH_EXCLUDEDNETWORKS_IPV4 | quote }}
-{{- end }}
-{{- if .Values.addons.vpn.wireguard.KILLSWITCH_EXCLUDEDNETWORKS_IPV6 }}
-  - name: KILLSWITCH_EXCLUDEDNETWORKS_IPV4
-    value: {{ .Values.addons.vpn.wireguard.KILLSWITCH_EXCLUDEDNETWORKS_IPV6 | quote }}
+    value: {{ $excludednetworksv4 | quote }}
+{{- if .Values.addons.vpn.excludedNetworks_IPv6 }}
+  {{- $excludednetworksv6 := ""}}
+  {{- range .Values.addons.vpn.excludedNetworks_IPv4 }}
+    {{- $excludednetworksv6 =  ( printf "%v;%v" $excludednetworksv6 . ) }}
+  {{- end}}
+  - name: KILLSWITCH_EXCLUDEDNETWORKS_IPV6
+    value: {{ .Values.addons.vpn.excludedNetworks_IPv6 | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/library/common/templates/lib/controller/_autopermissions.yaml
+++ b/charts/library/common/templates/lib/controller/_autopermissions.yaml
@@ -27,8 +27,12 @@ before chart installation.
   command:
     - "/bin/sh"
     - "-c"
-    - "echo 'Automatically correcting permissions...';{{ range $_, $hpm := $hostPathMounts }}chown -R :{{ $group }} {{ $hpm.mountPath | squote }}; chmod -R g+w {{ $hpm.mountPath | squote }};{{ end }}"
+    - "echo 'Automatically correcting permissions...';{{ if .Values.addons.vpn.configFile }}chown -R 568:568 /vpn/vpn.conf; chmod -R g+w /vpn/vpn.conf;{{ end }}{{ range $_, $hpm := $hostPathMounts }}chown -R :{{ $group }} {{ $hpm.mountPath | squote }}; chmod -R g+w {{ $hpm.mountPath | squote }};{{ end }}"
   volumeMounts:
+    {{- if .Values.addons.vpn.configFile }}
+      - name: vpnconfig
+        mountPath: /vpn/vpn.conf
+    {{- end }}
     {{- range $name, $hpm := $hostPathMounts }}
     - name: {{ $name }}
       mountPath: {{ $hpm.mountPath }}

--- a/charts/library/common/tests/persistentvolumeclaim_test.go
+++ b/charts/library/common/tests/persistentvolumeclaim_test.go
@@ -81,7 +81,7 @@ func (suite *PersistenceVolumeClaimTestSuite) TestMetaData() {
         "app.kubernetes.io/managed-by": "Helm",
         "app.kubernetes.io/name":       "common-test",
         "app.kubernetes.io/version":"latest",
-        "helm.sh/chart":                "common-test-3.1.2",
+        "helm.sh/chart":                "common-test-3.1.3",
     }
 
     tests := map[string]struct {

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -698,15 +698,14 @@ addons:
     # @default -- See below
     openvpn:
       # -- Credentials to connect to the VPN Service (used with -a)
-      auth:  # "user;password"
-      # -- Optionally specify an existing secret that contains the credentials.
-      # Credentials should be stored under the `VPN_AUTH` key
-      authSecret:  # my-vpn-secret
+      # Only using password is enough
+      username: ""
+      password: ""
 
-    wireguard:
-      KILLSWITCH: false
-      KILLSWITCH_EXCLUDEDNETWORKS_IPV4:
-        - 192.168.0.0.1
+    killSwitch: true
+    excludedNetworks_IPv4: []
+    excludedNetworks_IPv6: []
+
     # -- Set the VPN container specific securityContext
     # @default -- See values.yaml
     securityContext: {}
@@ -725,7 +724,7 @@ addons:
 
     # -- Provide a customized vpn configuration file to be used by the VPN.
     configFile:
-      enabled: false
+      enabled: true
       type: hostPath
       # -- Which path on the host should be mounted.
       hostPath: /vpn/vpn.conf

--- a/templates/questions/addons.yaml
+++ b/templates/questions/addons.yaml
@@ -28,35 +28,52 @@
                   type: dict
                   show_if: [["type", "=", "openvpn"]]
                   attrs:
-                    - variable: auth
-                      label: "authentication credentials"
-                      description: "authentication credentials, seperated by ;  example: username;password"
+                    - variable: username
+                      label: "authentication username"
+                      description: "authentication username, optional"
                       schema:
                         type: string
                         default: ""
-              - variable: wireguard
-                label: "Wireguard Settings"
+                    - variable: password
+                      label: "authentication password"
+                      description: "authentication credentials"
+                      schema:
+                        type: string
+                        default: ""
+                        required: true
+              - variable: killSwitch
+                label: "Enable killswitch"
                 schema:
-                  type: dict
-                  show_if: [["type", "=", "wireguard"]]
-                  attrs:
-                    - variable: KILLSWITCH
-                      label: "Enable killswitch"
-                      schema:
-                        type: boolean
-                        default: false
-                    - variable: KILLSWITCH_EXCLUDEDNETWORKS_IPV4
-                      label: "Killswitch Excluded IPv4 networks"
-                      description: "list of killswitch excluded ipv4 addresses seperated by ;"
-                      schema:
-                        type: string
-                        default: "172.16.0.0/12"
-                    - variable: KILLSWITCH_EXCLUDEDNETWORKS_IPV6
-                      label: "Killswitch Excluded IPv6 networks"
-                      description: "list of killswitch excluded ipv4 addresses seperated by ;"
+                  type: boolean
+                  show_if: [["type", "!=", "disabled"]]
+                  default: true
+              - variable: excludedNetworks_IPv4
+                label: "Killswitch Excluded IPv4 networks"
+                description: "list of killswitch excluded ipv4 addresses"
+                schema:
+                  type: list
+                  show_if: [["type", "!=", "disabled"]]
+                  default: []
+                  items:
+                    - variable: networkv4
+                      label: "IPv4 Network"
                       schema:
                         type: string
-                        default: ""
+                        required: true
+              - variable: excludedNetworks_IPv6
+                label: "Killswitch Excluded IPv6 networks"
+                description: "list of killswitch excluded ipv4 addresses"
+                schema:
+                  type: list
+                  show_if: [["type", "!=", "disabled"]]
+                  default: []
+                  items:
+                    - variable: networkv6
+                      label: "IPv6 Network"
+                      schema:
+                        type: string
+                        required: true
+
               - variable: configFile
                 label: "VPN Config File Location"
                 schema:
@@ -89,9 +106,10 @@
                         hidden: true
                     - variable: hostPath
                       label: "Full path to file"
+                      description: "path to your local VPN config file for example: /mnt/tank/vpn.conf or /mnt/tank/vpn.ovpn"
                       schema:
                         type: string
-                        default: "/mnt/tank/config/YourVPN-Config.conf"
+                        default: ""
                         required: true
               - variable: envList
                 label: "VPN environment Variables"


### PR DESCRIPTION
**Description**
This PR makes the VPN interface more uniform and fixes remaining (permissions related) issues with VPN.

In short: Both OpenVPN and Wireguard should now use the same killswitch UI and ownership of the vpn config file will actually always been taken

**Type of change**

- [X] Feature/App addition
- [X] Bugfix
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
