### PR TITLE
Add ReadOnlyRoot mitigation for S6 overlay

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.0.1
+version: 8.0.2

--- a/charts/library/common/templates/lib/controller/_container.tpl
+++ b/charts/library/common/templates/lib/controller/_container.tpl
@@ -35,6 +35,10 @@
   {{- end }}
 
   env:
+   {{- if .Values.securityContext.readOnlyRootFilesystem }}
+    - name: S6_READ_ONLY_ROOT
+      value: "1"
+   {{- end }}
    {{- range $key, $value := .Values.envTpl }}
     - name: {{ $key }}
       value: {{ tpl $value $ | quote }}

--- a/charts/library/common/tests/container_test.go
+++ b/charts/library/common/tests/container_test.go
@@ -98,14 +98,14 @@ func (suite *ContainerTestSuite) TestEnv() {
         values      []string
         expectedEnv map[string]string
     }{
-        "Default":                    {values: nil, expectedEnv: nil},
-        "KeyValueString":             {values: []string{"env.string=value_of_env"}, expectedEnv: map[string]string{"string": "value_of_env"}},
-        "KeyValueFloat":              {values: []string{"env.float=4.2"}, expectedEnv: map[string]string{"float": "4.2"}},
-        "KeyValueBool":               {values: []string{"env.bool=false"}, expectedEnv: map[string]string{"bool": "false"}},
-        "KeyValueInt":                {values: []string{"env.int=42"}, expectedEnv: map[string]string{"int": "42"}},
-        "KeyValue+ExplicitValueFrom": {values: []string{"env.STATIC_ENV=value_of_env", "env.STATIC_ENV_FROM.valueFrom.fieldRef.fieldPath=spec.nodeName"}, expectedEnv: map[string]string{"STATIC_ENV": "value_of_env", "STATIC_ENV_FROM": "spec.nodeName"}},
-        "ImplicitValueFrom":          {values: []string{"env.NODE_NAME.fieldRef.fieldPath=spec.nodeName"}, expectedEnv: map[string]string{"NODE_NAME": "spec.nodeName"}},
-        "Templated":                  {values: []string{`env.DYN_ENV=\{\{ .Release.Name \}\}-admin`}, expectedEnv: map[string]string{"DYN_ENV": "common-test-admin"}},
+        "Default":                    {values: nil, expectedEnv: map[string]string{"S6_READ_ONLY_ROOT":"1"}},
+        "KeyValueString":             {values: []string{"env.string=value_of_env"}, expectedEnv: map[string]string{"S6_READ_ONLY_ROOT":"1", "string": "value_of_env"}},
+        "KeyValueFloat":              {values: []string{"env.float=4.2"}, expectedEnv: map[string]string{"S6_READ_ONLY_ROOT":"1", "float": "4.2"}},
+        "KeyValueBool":               {values: []string{"env.bool=false"}, expectedEnv: map[string]string{"S6_READ_ONLY_ROOT":"1", "bool":"false"}},
+        "KeyValueInt":                {values: []string{"env.int=42"}, expectedEnv: map[string]string{"S6_READ_ONLY_ROOT":"1", "int": "42"}},
+        "KeyValue+ExplicitValueFrom": {values: []string{"env.STATIC_ENV=value_of_env", "env.STATIC_ENV_FROM.valueFrom.fieldRef.fieldPath=spec.nodeName"}, expectedEnv: map[string]string{"S6_READ_ONLY_ROOT":"1", "STATIC_ENV": "value_of_env", "STATIC_ENV_FROM": "spec.nodeName"}},
+        "ImplicitValueFrom":          {values: []string{"env.NODE_NAME.fieldRef.fieldPath=spec.nodeName"}, expectedEnv: map[string]string{"NODE_NAME": "spec.nodeName", "S6_READ_ONLY_ROOT":"1"}},
+        "Templated":                  {values: []string{`env.DYN_ENV=\{\{ .Release.Name \}\}-admin`}, expectedEnv: map[string]string{"DYN_ENV": "common-test-admin", "S6_READ_ONLY_ROOT":"1"}},
         "Mixed": {
             values: []string{
                 `env.DYN_ENV=\{\{ .Release.Name \}\}-admin`,
@@ -115,6 +115,7 @@ func (suite *ContainerTestSuite) TestEnv() {
             },
             expectedEnv: map[string]string{
                 "DYN_ENV":                  "common-test-admin",
+                "S6_READ_ONLY_ROOT":        "1", "
                 "STATIC_ENV":               "value_of_env",
                 "STATIC_EXPLICIT_ENV_FROM": "spec.nodeName",
                 "STATIC_IMPLICIT_ENV_FROM": "spec.nodeName",


### PR DESCRIPTION
**Description**
This adds the required S6 Env var if running on a read-only-root-filesystem

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
