### PR TITLE
add a special /var/run tmpfs mountpoint to common

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.0.3
+version: 8.0.4

--- a/charts/library/common/tests/persistentvolumeclaim_test.go
+++ b/charts/library/common/tests/persistentvolumeclaim_test.go
@@ -80,7 +80,7 @@ func (suite *PersistenceVolumeClaimTestSuite) TestMetaData() {
         "app.kubernetes.io/instance":   "common-test",
         "app.kubernetes.io/managed-by": "Helm",
         "app.kubernetes.io/name":       "common-test",
-        "app.kubernetes.io/version":"latest",
+        "app.kubernetes.io/version":"1.6.1",
         "helm.sh/chart":                "common-test-3.1.4",
     }
 

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -592,6 +592,22 @@ persistence:
     # -- If the `SizeMemoryBackedVolumes` feature gate is enabled, you can
     # specify a size for memory backed volumes.
     sizeLimit:  # 1Gi
+  # -- Create an emptyDir volume to share between all containers
+  # [[ref]]https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+  # @default -- See below
+  varrun:
+    enabled: true
+    type: emptyDir
+    mountPath: /var/run
+
+    # -- Set the medium to "Memory" to mount a tmpfs (RAM-backed filesystem) instead
+    # of the storage medium that backs the node.
+    medium: Memory
+
+    # -- If the `SizeMemoryBackedVolumes` feature gate is enabled, you can
+    # specify a size for memory backed volumes.
+    sizeLimit:  # 1Gi
+
 
   # -- Example of a hostPath mount
   # [[ref]]https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)


### PR DESCRIPTION
**Description**
When using a readonly root filesystem, a lot of systems (like s6 overlay) use /var/run to store temporary data.
As this path is, by design, assumed to be non-persistent, we can safely mount this as a tmpfs (ram backed) emptydir mountpoint.

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
