### PR TITLE
(fix) give gitea user more permissions over /data

### DIFF
--- a/charts/stable/gitea/Chart.yaml
+++ b/charts/stable/gitea/Chart.yaml
@@ -34,4 +34,4 @@ sources:
 - https://github.com/go-gitea/gitea
 - https://hub.docker.com/r/gitea/gitea/
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/charts/stable/gitea/templates/_secrets.tpl
+++ b/charts/stable/gitea/templates/_secrets.tpl
@@ -169,7 +169,7 @@ stringData:
 
     # Copy config file to writable volume
     cp /etc/gitea/conf/app.ini /data/gitea/conf/app.ini
-    chown -Rf {{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}  "/data/gitea"
+    chown -Rf {{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}  "/data"
     chmod a+rwx /data/gitea/conf/app.ini
 
     # Patch dockercontainer for dynamic users


### PR DESCRIPTION
**Description**
Gitea running as root seems to have some issues cloning repo's, this gives the gitea securityContext user more permissions over git.

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
