### PR TITLE
(fix) Fix collabora regex and secContext, move validation docs to per app

### DIFF
--- a/charts/stable/collabora-online/Chart.yaml
+++ b/charts/stable/collabora-online/Chart.yaml
@@ -25,4 +25,4 @@ sources:
 - https://sdk.collaboraonline.com/contents.html
 - https://github.com/CollaboraOnline/online/tree/master/kubernetes/helm
 type: application
-version: 8.0.3
+version: 8.0.4

--- a/charts/stable/collabora-online/Chart.yaml
+++ b/charts/stable/collabora-online/Chart.yaml
@@ -25,4 +25,4 @@ sources:
 - https://sdk.collaboraonline.com/contents.html
 - https://github.com/CollaboraOnline/online/tree/master/kubernetes/helm
 type: application
-version: 8.0.4
+version: 8.0.3

--- a/charts/stable/collabora-online/SCALE/questions.yaml
+++ b/charts/stable/collabora-online/SCALE/questions.yaml
@@ -85,7 +85,7 @@ questions:
           schema:
             type: string
             default: 'nextcloud\.domain\.tld|othernextcloud\.domain\.tld'
-            valid_chars: '^([a-z]{1,}\\{1}\.{1}[a-z]{1,}\\{1}\.{1}[a-z]{1,}\|{0,1})*$'
+            valid_chars: '^([a-z]{1,}\\\.[a-z]{1,}\\\.[a-z]{1,})((\|[a-z]{1,}\\\.[a-z]{1,}\\\.[a-z]{1,}))*$'
             required: true
         - variable: username
           label: "Username for WebUI"

--- a/charts/stable/collabora-online/SCALE/questions.yaml
+++ b/charts/stable/collabora-online/SCALE/questions.yaml
@@ -81,11 +81,11 @@ questions:
               - "definitions/timezone"
         - variable: domain
           label: "Domain(s) using collabora"
-          description: 'Use backslash "\" before dots ".". Use pipe "|" to separate multiple domains'
+          description: 'Use pipe "|" to separate multiple domains'
           schema:
             type: string
-            default: 'nextcloud\.domain\.tld|othernextcloud\.domain\.tld'
-            valid_chars: '^([a-z]{1,}\\\.[a-z]{1,}\\\.[a-z]{1,})((\|[a-z]{1,}\\\.[a-z]{1,}\\\.[a-z]{1,}))*$'
+            default: 'nextcloud.domain.tld|othernextcloud.domain.tld'
+            valid_chars: '^([a-z]{1,}\.[a-z]{1,}\.[a-z]{1,})((\|[a-z]{1,}\.[a-z]{1,}\.[a-z]{1,}))*$'
             required: true
         - variable: username
           label: "Username for WebUI"
@@ -123,8 +123,8 @@ questions:
           description: "When this environment variable is set (is not “”), then its value will be used as server name in /etc/loolwsd/loolwsd.xml. Without this, CODE is not delivering a correct host for the websocket connection in case of a proxy in front of it."
           schema:
             type: string
-            default: 'collabora\.domain\.tld'
-            valid_chars: '^[a-z]{1,}\\{1}\.{1}[a-z]{1,}\\{1}\.{1}[a-z]{1,}$'
+            default: 'collabora.domain.tld'
+            valid_chars: '^([a-z]{1,}\.[a-z]{1,}\.[a-z]{1,})$'
 # Include{containerConfig}
 
   - variable: service
@@ -484,7 +484,7 @@ questions:
           label: "Allow Privilege Escalation"
           schema:
             type: boolean
-            default: false
+            default: true
         - variable: runAsNonRoot
           label: "runAsNonRoot"
           schema:

--- a/charts/stable/collabora-online/values.yaml
+++ b/charts/stable/collabora-online/values.yaml
@@ -5,6 +5,7 @@ image:
 
 securityContext:
   readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
   runAsNonRoot: false
 
 podSecurityContext:

--- a/docs/apps/stable/appdaemon/validation.md
+++ b/docs/apps/stable/appdaemon/validation.md
@@ -1,0 +1,13 @@
+# Input Validation
+
+__`LATITUDE`__ and __`LONGITUDE`__
+Accepted formats are:
+
+- Float (eg. `24.2028`)
+
+Regex used to match this: `^[0-9]{1,}\.{1}[0-9]{1,}$`
+You can try live [here](https://regex101.com/r/xsLGWN/1)
+
+---
+
+_If you find a field that you think it needs validation, please open an issue on github_

--- a/docs/apps/stable/collabora-online/validation.md
+++ b/docs/apps/stable/collabora-online/validation.md
@@ -1,0 +1,30 @@
+# Input Validation
+
+__`Domain(s) using collabora`__
+Accepted formats are:
+
+- Single domain (eg. `cloud.mydomain.com`)
+- Multiple domains (eg. `cloud.mydomain.com|nextcloud.mydomain.com`) - Each domain is separated with `|`
+
+Regex used to match those: `^([a-z]{1,}\.[a-z]{1,}\.[a-z]{1,})((\|[a-z]{1,}\.[a-z]{1,}\.[a-z]{1,}))*$`
+You can try live [here](https://regex101.com/r/AQFh2g/1)
+
+__`Server Name`__
+Accepted formats are:
+
+- Single domain (eg. `collabora.mydomain.com`)
+
+Regex used to match this: `^([a-z]{1,}\.[a-z]{1,}\.[a-z]{1,})$`
+You can try live [here](https://regex101.com/r/xCjpW7/1)
+
+__`Password for WebUI`__
+Accepted formats are:
+
+- Letters, Numbers, Symbols, Minimum 8 characters (eg. `dg523$*a`) - It accepts `a-z`, `A-Z`, `0-9` and `!@#$%^&*?`
+
+Regex used to match those: `[a-zA-Z0-9!@#$%^&*?]{8,}`
+You can try live [here](https://regex101.com/r/ef3V88/1)
+
+---
+
+_If you find a field that you think it needs validation, please open an issue on github_

--- a/docs/apps/stable/fireflyiii/validation.md
+++ b/docs/apps/stable/fireflyiii/validation.md
@@ -1,0 +1,13 @@
+# Input Validation
+
+__`APP_KEY`__
+Accepted formats are:
+
+- Letters, Numbers, Symbols, Exactly 32 characters (eg. `!oqVA9o2@br#$6vAyk8LLrDm54X5EtjD`) - It accepts `a-z`, `A-Z`, `0-9` and `!@#$%^&*?`
+
+You can try live [here](https://regex101.com/r/OR879w/1)
+Regex used to match this: `[a-zA-Z0-9!@#$%^&*?]{32}`
+
+---
+
+_If you find a field that you think it needs validation, please open an issue on github_

--- a/docs/manual/indepth/validation.md
+++ b/docs/manual/indepth/validation.md
@@ -55,8 +55,8 @@ Accepted formats are:
 - Single domain (eg. `cloud\.mydomain\.com`) - Each `.` has to be escaped with `\`
 - Multiple domains (eg. `cloud\.mydomain\.com|nextcloud\.mydomain\.com`) - Each `.` has to be escaped with `\` and each domain is separated with `|`
 
-Regex used to match those: `^([a-z]{1,}\\{1}\.{1}[a-z]{1,}\\{1}\.{1}[a-z]{1,}\|{0,1})*$`
-You can try live [here](https://regex101.com/r/LK02xa/1)
+Regex used to match those: `^([a-z]{1,}\\\.[a-z]{1,}\\\.[a-z]{1,})((\|[a-z]{1,}\\\.[a-z]{1,}\\\.[a-z]{1,}))*$`
+You can try live [here](https://regex101.com/r/SKQFz7/1)
 
 __`Password for WebUI`__
 Accepted formats are:

--- a/docs/manual/indepth/validation.md
+++ b/docs/manual/indepth/validation.md
@@ -31,52 +31,6 @@ Regex uesd to match those: `^(?!^0(e[0-9]|[EPTGMK]i?|)$)([0-9]+)(|[EPTGMK]i?|e[0
 You can try live [here](https://regex101.com/r/LyDc6u/1)
 More detailed info can be found [here](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory)
 
-
-### Per app validation
-
----
-
-#### Appdaemon
-
-__`LATITUDE`__ and __`LONGITUDE`__
-Accepted formats are:
-
-- Float (eg. `24.2028`)
-
-Regex used to match this: `^[0-9]{1,}\.{1}[0-9]{1,}$`
-You can try live [here](https://regex101.com/r/xsLGWN/1)
-
-
-#### Collabora
-
-__`Domain(s) using collabora`__
-Accepted formats are:
-
-- Single domain (eg. `cloud\.mydomain\.com`) - Each `.` has to be escaped with `\`
-- Multiple domains (eg. `cloud\.mydomain\.com|nextcloud\.mydomain\.com`) - Each `.` has to be escaped with `\` and each domain is separated with `|`
-
-Regex used to match those: `^([a-z]{1,}\\\.[a-z]{1,}\\\.[a-z]{1,})((\|[a-z]{1,}\\\.[a-z]{1,}\\\.[a-z]{1,}))*$`
-You can try live [here](https://regex101.com/r/SKQFz7/1)
-
-__`Password for WebUI`__
-Accepted formats are:
-
-- Letters, Numbers, Symbols, Minimum 8 characters (eg. `dg523$*a`) - It accepts `a-z`, `A-Z`, `0-9` and `!@#$%^&*?`
-
-Regex used to match those: `[a-zA-Z0-9!@#$%^&*?]{8,}`
-You can try live [here](https://regex101.com/r/ef3V88/1)
-
-
-#### Fireflyiii
-
-__`APP_KEY`__
-Accepted formats are:
-
-- Letters, Numbers, Symbols, Exactly 32 characters (eg. `!oqVA9o2@br#$6vAyk8LLrDm54X5EtjD`) - It accepts `a-z`, `A-Z`, `0-9` and `!@#$%^&*?`
-
-You can try live [here](https://regex101.com/r/OR879w/1)
-Regex used to match this: `[a-zA-Z0-9!@#$%^&*?]{32}`
-
 ---
 
 _If you find a field that you think it needs validation, please open an issue on github_


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
There was some cases that would allow people have `|` on the start or on the end of the domain list, which is not something collabora likes. It needs to be only between domains


**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
