### PR TITLE
(feat) automaticly set CAP_NET_BIND_SERVICE based on port in services

### DIFF
--- a/.github/workflows/apps.test.yaml
+++ b/.github/workflows/apps.test.yaml
@@ -127,7 +127,7 @@ jobs:
         if: ${{ matrix.app != 'common' &&  matrix.app != '.gitkee' }}
         uses: nolar/setup-k3d-k3s@v1
         with:
-          version: v1.19
+          version: v1.22.2+k3s1
 
       ## TODO: Fix common-test
       - name: Run chart-testing (install)

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.0.13
+version: 8.1.0

--- a/charts/library/common/templates/lib/chart/_values.tpl
+++ b/charts/library/common/templates/lib/chart/_values.tpl
@@ -137,6 +137,7 @@
   {{- $_ := set .Values.securityContext "privileged" true -}}
   {{- end }}
 
+
   {{/* save supplementalGroups to placeholder variables */}}
   {{- $fixedGroups := list 568 }}
   {{- $valuegroups := list }}
@@ -195,4 +196,55 @@
   {{- end }}
   {{- end }}
 
+
+  {{/* automatically set CAP_NET_BIND_SERVICE */}}
+  {{- $fixedCapAdd := list }}
+  {{- $customCapAdd := list }}
+  {{- $valueCapAdd := list }}
+  {{- $dynamicCapAdd := list }}
+  {{- $fixedCapDrop := list }}
+  {{- $customCapDrop := list }}
+  {{- $valueCapDrop := list }}
+  {{- $dynamicCapDrop := list }}
+  {{- if .Values.securityContext.capabilities.add }}
+  {{- $valueCapAdd = .Values.securityContext.capabilities.add }}
+  {{- end }}
+  {{- if .Values.securityContext.capabilities.drop }}
+  {{- $valueCapDrop = .Values.securityContext.capabilities.drop }}
+  {{- end }}
+  {{- if .Values.customCapabilities.add }}
+  {{- $customCapAdd = .Values.customCapabilities.add }}
+  {{- end }}
+  {{- if .Values.customCapabilities.drop }}
+  {{- $customCapDrop = .Values.customCapabilities.drop }}
+  {{- end }}
+
+  {{- $privPort := false }}
+  {{- range .Values.service }}
+  {{- range $name, $values := .ports }}
+  {{- if and ( $values.targetPort ) ( kindIs "int" $values.targetPort ) }}
+  {{- if ( semverCompare "<= 1024" ( toString $values.targetPort ) ) }}
+  {{- $privPort = true }}
+  {{- end }}
+  {{- else }}
+  {{- if ( semverCompare "<= 1024" ( toString $values.port ) ) }}
+  {{- $privPort = true }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+
+  {{- if $privPort }}
+  {{- $dynamicCapAdd = list "NET_BIND_SERVICE" }}
+  {{- end }}
+
+  {{/* combine and write all capabilities to .Values */}}
+  {{- $CapAdd := concat $fixedCapAdd $valueCapAdd $dynamicCapAdd }}
+  {{- $CapDrop := concat $fixedCapDrop $valueCapDrop $dynamicCapDrop }}
+  {{- if $CapDrop }}
+  {{- $_ := set .Values.securityContext.capabilities "drop" $CapDrop -}}
+  {{- end }}
+  {{- if $CapAdd }}
+  {{- $_ := set .Values.securityContext.capabilities "add" $CapAdd -}}
+  {{- end }}
 {{- end -}}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -244,6 +244,11 @@ dnsConfig:
 # [[ref]](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service)
 enableServiceLinks: false
 
+# -- Can be used to set securityContext.capabilities outside of the GUI on TrueNAS SCALE
+customCapabilities:
+  drop: []
+  add: []
+
 # -- Configure the Security Context for the Pod
 podSecurityContext:
   runAsUser: 568
@@ -258,6 +263,10 @@ securityContext:
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsNonRoot: true
+  capabilities:
+    drop: []
+    add: []
+
 
 # -- Configure the lifecycle for the main container
 lifecycle: {}


### PR DESCRIPTION
**Description**
We want to run as non-root as much as possible, this by default causes issues with the many containers that try to use port 80, which requires CAP_NET_BIND_SERVICE to be set.

As it's rather error prone to force App creators to manually add that every time, this PR assures it is set on every App that includes a service running below port 1024

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
