### PR TITLE
(chore) move standardised env-vars to include

### DIFF
--- a/charts/incubator/onlyoffice-document-server/SCALE/questions.yaml
+++ b/charts/incubator/onlyoffice-document-server/SCALE/questions.yaml
@@ -75,13 +75,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: WOPI_ENABLED
           label: "WOPI_ENABLED"
           description: "Specifies the enabling the wopi handlers."

--- a/charts/incubator/sogo/SCALE/questions.yaml
+++ b/charts/incubator/sogo/SCALE/questions.yaml
@@ -72,19 +72,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: sogo

--- a/charts/stable/airsonic/SCALE/questions.yaml
+++ b/charts/stable/airsonic/SCALE/questions.yaml
@@ -72,13 +72,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -86,12 +80,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/appdaemon/SCALE/questions.yaml
+++ b/charts/stable/appdaemon/SCALE/questions.yaml
@@ -72,13 +72,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: HA_URL
           label: "HA URL"
           description: "Your HomeAssistant URL"
@@ -123,12 +117,7 @@ questions:
             type: int
             default: 0
             required: true
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/authelia/SCALE/questions.yaml
+++ b/charts/stable/authelia/SCALE/questions.yaml
@@ -72,19 +72,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: domain

--- a/charts/stable/bazarr/SCALE/questions.yaml
+++ b/charts/stable/bazarr/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/booksonic-air/SCALE/questions.yaml
+++ b/charts/stable/booksonic-air/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the userID inside the container"
@@ -90,12 +84,7 @@ questions:
           schema:
             type: string
             default: "568"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/calibre-web/SCALE/questions.yaml
+++ b/charts/stable/calibre-web/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -85,12 +79,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/calibre/SCALE/questions.yaml
+++ b/charts/stable/calibre/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the userID inside the container"

--- a/charts/stable/collabora-online/SCALE/questions.yaml
+++ b/charts/stable/collabora-online/SCALE/questions.yaml
@@ -72,13 +72,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: domain
           label: "Domain(s) using collabora"
           description: 'Use pipe "|" to separate multiple domains'

--- a/charts/stable/custom-app/SCALE/questions.yaml
+++ b/charts/stable/custom-app/SCALE/questions.yaml
@@ -104,13 +104,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/deconz/SCALE/questions.yaml
+++ b/charts/stable/deconz/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
         - variable: DECONZ_DEVICE
           label: "DECONZ_DEVICE"
           description: "Override the location where deCONZ looks for the RaspBee/Conbee device"

--- a/charts/stable/deepstack-cpu/SCALE/questions.yaml
+++ b/charts/stable/deepstack-cpu/SCALE/questions.yaml
@@ -73,13 +73,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -87,12 +81,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
         - variable: VISION-FACE
           label: "VISION-FACE"
           description: "Enables Face Detection"

--- a/charts/stable/deluge/SCALE/questions.yaml
+++ b/charts/stable/deluge/SCALE/questions.yaml
@@ -86,12 +86,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 
 # Include{containerConfig}
 

--- a/charts/stable/dizquetv/SCALE/questions.yaml
+++ b/charts/stable/dizquetv/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the userID inside the container"
@@ -90,12 +84,7 @@ questions:
           schema:
             type: string
             default: "568"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/duplicati/SCALE/questions.yaml
+++ b/charts/stable/duplicati/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the userID inside the container"
@@ -90,12 +84,7 @@ questions:
           schema:
             type: string
             default: "568"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/emby/SCALE/questions.yaml
+++ b/charts/stable/emby/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/esphome/SCALE/questions.yaml
+++ b/charts/stable/esphome/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/fireflyiii/SCALE/questions.yaml
+++ b/charts/stable/fireflyiii/SCALE/questions.yaml
@@ -72,13 +72,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: APP_KEY
           label: "App Key"
           description: "Your unique 32 application character key"
@@ -89,12 +83,7 @@ questions:
             max_length: 32
             valid_chars: '[a-zA-Z0-9!@#$%^&*?]{32}'
             required: true
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/flaresolverr/SCALE/questions.yaml
+++ b/charts/stable/flaresolverr/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/flood/SCALE/questions.yaml
+++ b/charts/stable/flood/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
         - variable: FLOOD_OPTION_RUNDIR
           label: "FLOOD_OPTION_RUNDIR"
           description: "Where to store Flood's runtime files (eg. database)"

--- a/charts/stable/focalboard/SCALE/questions.yaml
+++ b/charts/stable/focalboard/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/freeradius/SCALE/questions.yaml
+++ b/charts/stable/freeradius/SCALE/questions.yaml
@@ -64,19 +64,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 
 # Include{containerConfig}
 

--- a/charts/stable/freshrss/SCALE/questions.yaml
+++ b/charts/stable/freshrss/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -85,12 +79,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/gaps/SCALE/questions.yaml
+++ b/charts/stable/gaps/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/gitea/SCALE/questions.yaml
+++ b/charts/stable/gitea/SCALE/questions.yaml
@@ -72,19 +72,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: admin

--- a/charts/stable/gonic/SCALE/questions.yaml
+++ b/charts/stable/gonic/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/grocy/SCALE/questions.yaml
+++ b/charts/stable/grocy/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -85,12 +79,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/handbrake/SCALE/questions.yaml
+++ b/charts/stable/handbrake/SCALE/questions.yaml
@@ -72,13 +72,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -86,12 +80,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
         - variable: gui
           label: "GUI Settings"
           description: "Always read description before changing a value here. Also refer to README"

--- a/charts/stable/haste-server/SCALE/questions.yaml
+++ b/charts/stable/haste-server/SCALE/questions.yaml
@@ -72,13 +72,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: STORAGE_FILEPATH
           label: "STORAGE_FILEPATH"
           schema:
@@ -89,12 +83,7 @@ questions:
           schema:
             type: string
             default: "file"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/healthchecks/SCALE/questions.yaml
+++ b/charts/stable/healthchecks/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
         - variable: REGENERATE_SETTINGS
           label: "REGENERATE_SETTINGS"
           description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"

--- a/charts/stable/heimdall/SCALE/questions.yaml
+++ b/charts/stable/heimdall/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -85,12 +79,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/home-assistant/SCALE/questions.yaml
+++ b/charts/stable/home-assistant/SCALE/questions.yaml
@@ -87,13 +87,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -101,12 +95,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/hyperion-ng/SCALE/questions.yaml
+++ b/charts/stable/hyperion-ng/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the userID inside the container"
@@ -90,12 +84,7 @@ questions:
           schema:
             type: string
             default: "568"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/jackett/SCALE/questions.yaml
+++ b/charts/stable/jackett/SCALE/questions.yaml
@@ -72,19 +72,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/jdownloader2/SCALE/questions.yaml
+++ b/charts/stable/jdownloader2/SCALE/questions.yaml
@@ -72,13 +72,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for jdownloader2 containers"

--- a/charts/stable/jellyfin/SCALE/questions.yaml
+++ b/charts/stable/jellyfin/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/k8s-gateway/SCALE/questions.yaml
+++ b/charts/stable/k8s-gateway/SCALE/questions.yaml
@@ -64,19 +64,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: domains

--- a/charts/stable/kms/SCALE/questions.yaml
+++ b/charts/stable/kms/SCALE/questions.yaml
@@ -63,13 +63,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -77,12 +71,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/komga/SCALE/questions.yaml
+++ b/charts/stable/komga/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/lazylibrarian/SCALE/questions.yaml
+++ b/charts/stable/lazylibrarian/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -85,12 +79,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/librespeed/SCALE/questions.yaml
+++ b/charts/stable/librespeed/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the userID inside the container"
@@ -90,12 +84,7 @@ questions:
           schema:
             type: string
             default: "568"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/lidarr/SCALE/questions.yaml
+++ b/charts/stable/lidarr/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/littlelink/SCALE/questions.yaml
+++ b/charts/stable/littlelink/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: littlelink

--- a/charts/stable/lychee/SCALE/questions.yaml
+++ b/charts/stable/lychee/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -85,12 +79,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/mealie/SCALE/questions.yaml
+++ b/charts/stable/mealie/SCALE/questions.yaml
@@ -72,24 +72,13 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: DB_TYPE
           label: "DB_TYPE"
           schema:
             type: string
             default: "sqlite"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/mosquitto/SCALE/questions.yaml
+++ b/charts/stable/mosquitto/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
   - variable: auth
     group: "App Configuration"
     label: "Authentication"

--- a/charts/stable/mylar/SCALE/questions.yaml
+++ b/charts/stable/mylar/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the userID inside the container"
@@ -90,12 +84,7 @@ questions:
           schema:
             type: string
             default: "568"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/navidrome/SCALE/questions.yaml
+++ b/charts/stable/navidrome/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/nextcloud/SCALE/questions.yaml
+++ b/charts/stable/nextcloud/SCALE/questions.yaml
@@ -72,19 +72,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
         - variable: NEXTCLOUD_ADMIN_USER
           label: "NEXTCLOUD_ADMIN_USER"
           description: "Sets nextcloud admin username"

--- a/charts/stable/node-red/SCALE/questions.yaml
+++ b/charts/stable/node-red/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/nullserv/SCALE/questions.yaml
+++ b/charts/stable/nullserv/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/nzbget/SCALE/questions.yaml
+++ b/charts/stable/nzbget/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/nzbhydra/SCALE/questions.yaml
+++ b/charts/stable/nzbhydra/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/octoprint/SCALE/questions.yaml
+++ b/charts/stable/octoprint/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
         - variable: ENABLE_MJPG_STREAMER
           label: "ENABLE_MJPG_STREAMER"
           description: "Enable this to ensure camera streaming is enabled you add a video device"

--- a/charts/stable/omada-controller/SCALE/questions.yaml
+++ b/charts/stable/omada-controller/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/ombi/SCALE/questions.yaml
+++ b/charts/stable/ombi/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/openldap/SCALE/questions.yaml
+++ b/charts/stable/openldap/SCALE/questions.yaml
@@ -64,19 +64,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
         - variable: LDAP_LOG_LEVEL
           label: "LDAP_LOG_LEVEL"
           schema:

--- a/charts/stable/organizr/SCALE/questions.yaml
+++ b/charts/stable/organizr/SCALE/questions.yaml
@@ -65,19 +65,14 @@ questions:
               - value: "OnDelete"
                 description: "(Legacy) OnDelete: ignore .spec.template changes"
 # Include{controllerExpert}
+
   - variable: env
     group: "Container Configuration"
     label: "Image Environment"
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -85,12 +80,6 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/oscam/SCALE/questions.yaml
+++ b/charts/stable/oscam/SCALE/questions.yaml
@@ -72,13 +72,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the userID inside the container"
@@ -91,12 +85,7 @@ questions:
           schema:
             type: string
             default: "20"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/overseerr/SCALE/questions.yaml
+++ b/charts/stable/overseerr/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
         - variable: LOG_LEVEL
           label: "LOG_LEVEL"
           description: "Set the application log level"

--- a/charts/stable/owncast/SCALE/questions.yaml
+++ b/charts/stable/owncast/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/owncloud-ocis/SCALE/questions.yaml
+++ b/charts/stable/owncloud-ocis/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/pgadmin/SCALE/questions.yaml
+++ b/charts/stable/pgadmin/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"

--- a/charts/stable/photoprism/SCALE/questions.yaml
+++ b/charts/stable/photoprism/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the userID inside the container"
@@ -90,12 +84,7 @@ questions:
           schema:
             type: string
             default: "568"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
         - variable: PHOTOPRISM_STORAGE_PATH
           label: "PHOTOPRISM_STORAGE_PATH"
           description: "Photoprism storage path"

--- a/charts/stable/phpldapadmin/SCALE/questions.yaml
+++ b/charts/stable/phpldapadmin/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
         - variable: PHPLDAPADMIN_HTTPS
           label: "PHPLDAPADMIN_HTTPS"
           schema:

--- a/charts/stable/piaware/SCALE/questions.yaml
+++ b/charts/stable/piaware/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/pihole/SCALE/questions.yaml
+++ b/charts/stable/pihole/SCALE/questions.yaml
@@ -81,19 +81,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 
 # Include{containerConfig}
 

--- a/charts/stable/plex/SCALE/questions.yaml
+++ b/charts/stable/plex/SCALE/questions.yaml
@@ -72,13 +72,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: ADVERTISE_IP
           label: "Advertise IP"
           description: "IP to advertise to Plex"
@@ -97,12 +91,7 @@ questions:
           schema:
             type: string
             default: ""
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/podgrab/SCALE/questions.yaml
+++ b/charts/stable/podgrab/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PASSWORD
           label: "Password"
           description: "Desired Password"

--- a/charts/stable/postgresql/SCALE/questions.yaml
+++ b/charts/stable/postgresql/SCALE/questions.yaml
@@ -64,13 +64,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
 
 # Include{containerConfig}
 

--- a/charts/stable/pretend-youre-xyzzy/SCALE/questions.yaml
+++ b/charts/stable/pretend-youre-xyzzy/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/protonmail-bridge/SCALE/questions.yaml
+++ b/charts/stable/protonmail-bridge/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/prowlarr/SCALE/questions.yaml
+++ b/charts/stable/prowlarr/SCALE/questions.yaml
@@ -72,19 +72,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/pyload/SCALE/questions.yaml
+++ b/charts/stable/pyload/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the userID inside the container"
@@ -90,12 +84,7 @@ questions:
           schema:
             type: string
             default: "568"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/qbittorrent/SCALE/questions.yaml
+++ b/charts/stable/qbittorrent/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/radarr/SCALE/questions.yaml
+++ b/charts/stable/radarr/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/readarr/SCALE/questions.yaml
+++ b/charts/stable/readarr/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/reg/SCALE/questions.yaml
+++ b/charts/stable/reg/SCALE/questions.yaml
@@ -72,19 +72,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/resilio-sync/SCALE/questions.yaml
+++ b/charts/stable/resilio-sync/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the userID inside the container"
@@ -90,12 +84,7 @@ questions:
           schema:
             type: string
             default: "568"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/sabnzbd/SCALE/questions.yaml
+++ b/charts/stable/sabnzbd/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: HOST_WHITELIST_ENTRIES
           label: "HostName Whitelist"
           description: "If you use a reverse proxy, you might need to enter your hostname's here (comma seperated)"
@@ -85,12 +79,7 @@ questions:
             type: string
             default: ""
             required: false
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/ser2sock/SCALE/questions.yaml
+++ b/charts/stable/ser2sock/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
         - variable: BAUD_RATE
           label: "BAUD_RATE"
           description: "Serial device baud rate"

--- a/charts/stable/sonarr/SCALE/questions.yaml
+++ b/charts/stable/sonarr/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/stash/SCALE/questions.yaml
+++ b/charts/stable/stash/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
         - variable: STASH_PORT
           label: "STASH_PORT"
           schema:

--- a/charts/stable/syncthing/SCALE/questions.yaml
+++ b/charts/stable/syncthing/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/tautulli/SCALE/questions.yaml
+++ b/charts/stable/tautulli/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/teamspeak3/SCALE/questions.yaml
+++ b/charts/stable/teamspeak3/SCALE/questions.yaml
@@ -65,13 +65,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: TS3SERVER_LICENSE
           label: "TS3SERVER_LICENSE"
           description: "Accept TS3SERVER LICENSE"

--- a/charts/stable/thelounge/SCALE/questions.yaml
+++ b/charts/stable/thelounge/SCALE/questions.yaml
@@ -72,24 +72,13 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: THELOUNGE_HOME
           label: "THELOUNGE_HOME"
           schema:
             type: string
             default: "/config"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/traefik/SCALE/questions.yaml
+++ b/charts/stable/traefik/SCALE/questions.yaml
@@ -72,19 +72,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: pilot

--- a/charts/stable/transmission/SCALE/questions.yaml
+++ b/charts/stable/transmission/SCALE/questions.yaml
@@ -73,19 +73,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
         - variable: TRANSMISSION_ALT_SPEED_DOWN
           label: TRANSMISSION_ALT_SPEED_DOWN
           schema:

--- a/charts/stable/truecommand/SCALE/questions.yaml
+++ b/charts/stable/truecommand/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -85,12 +79,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/tvheadend/SCALE/questions.yaml
+++ b/charts/stable/tvheadend/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -85,12 +79,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/unifi/SCALE/questions.yaml
+++ b/charts/stable/unifi/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
         - variable: PUID
           label: "PUID"
           description: "Sets the PUID env var for LinuxServer.io (compatible) containers"
@@ -85,12 +79,7 @@ questions:
             type: int
             default: 568
 
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/unpackerr/SCALE/questions.yaml
+++ b/charts/stable/unpackerr/SCALE/questions.yaml
@@ -49,19 +49,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: serviceexpert

--- a/charts/stable/vaultwarden/SCALE/questions.yaml
+++ b/charts/stable/vaultwarden/SCALE/questions.yaml
@@ -72,19 +72,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: vaultwarden

--- a/charts/stable/xteve/SCALE/questions.yaml
+++ b/charts/stable/xteve/SCALE/questions.yaml
@@ -71,19 +71,8 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
-        - variable: UMASK
-          label: "UMASK"
-          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
-          schema:
-            type: string
-            default: "002"
+# Include{fixedEnv}
+
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/zwavejs2mqtt/SCALE/questions.yaml
+++ b/charts/stable/zwavejs2mqtt/SCALE/questions.yaml
@@ -71,13 +71,7 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: TZ
-          label: "Timezone"
-          schema:
-            type: string
-            default: "Etc/UTC"
-            $ref:
-              - "definitions/timezone"
+# Include{fixedEnv}
 # Include{containerConfig}
 
   - variable: service

--- a/templates/questions/fixedEnv.yaml
+++ b/templates/questions/fixedEnv.yaml
@@ -1,0 +1,13 @@
+        - variable: TZ
+          label: "Timezone"
+          schema:
+            type: string
+            default: "Etc/UTC"
+            $ref:
+              - "definitions/timezone"
+        - variable: UMASK
+          label: "UMASK"
+          description: "Sets the UMASK env var for LinuxServer.io (compatible) containers"
+          schema:
+            type: string
+            default: "002"

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -131,6 +131,11 @@ include_questions(){
     /# Include{groups}/ { for (i=0;i<n;++i) print a[i]; next }
     1' templates/questions/groups.yaml ${target}/questions.yaml > tmp && mv tmp ${target}/questions.yaml
 
+    # Replace # Include{fixedEnv} with the standard groups codesnippet
+    awk 'NR==FNR { a[n++]=$0; next }
+    /# Include{fixedEnv}/ { for (i=0;i<n;++i) print a[i]; next }
+    1' templates/questions/fixedEnv.yaml ${target}/questions.yaml > tmp && mv tmp ${target}/questions.yaml
+
      # Replace # Include{controllerExpert} with the standard controllerExpert codesnippet
     awk 'NR==FNR { a[n++]=$0; next }
     /# Include{controllerExpert}/ { for (i=0;i<n;++i) print a[i]; next }


### PR DESCRIPTION
**Description**
Currently some env-vars are included in every App, this leads to needless code-bloat.
Moving them to an include cleans that up quite nicely.

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
