### PR TITLE
(fix) always mount /tmp as emptydir by default for readOnlyRootFilesystem

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.2.0
+version: 8.2.1

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -596,6 +596,20 @@ persistence:
     # -- If the `SizeMemoryBackedVolumes` feature gate is enabled, you can
     # specify a size for memory backed volumes.
     sizeLimit:  # 1Gi
+
+  # -- Create an emptyDir volume to share between all containers for temporary storage
+  # @default -- See below
+  temp:
+    enabled: true
+    type: emptyDir
+    mountPath: /tmp
+    # -- Set the medium to "Memory" to mount a tmpfs (RAM-backed filesystem) instead
+    # of the storage medium that backs the node.
+    medium: Memory
+    # -- If the `SizeMemoryBackedVolumes` feature gate is enabled, you can
+    # specify a size for memory backed volumes.
+    sizeLimit:  # 1Gi
+
   # -- Create an emptyDir volume to share between all containers
   # [[ref]]https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
   # @default -- See below
@@ -609,6 +623,7 @@ persistence:
     # -- If the `SizeMemoryBackedVolumes` feature gate is enabled, you can
     # specify a size for memory backed volumes.
     sizeLimit:  # 1Gi
+
 
   # -- Example of a hostPath mount
   # [[ref]]https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)


### PR DESCRIPTION
**Description**
When running a readOnlyRootFilesystem, the /tmp directory is not writeable (obviously).
This is causing all sorts of issues for Apps that would normally work fine with readOnlyRootFilesystem.

This PR creates a default memory-backed emptyDir volume under /tmp, which basically emulates the default behavior of host /tmp

fixes: #1067

**Type of change**

- [X] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
