### PR TITLE
(fix) view cluster as trusted proxy for Home Assistant

### DIFF
--- a/charts/stable/home-assistant/Chart.yaml
+++ b/charts/stable/home-assistant/Chart.yaml
@@ -29,4 +29,4 @@ sources:
 - https://github.com/home-assistant/home-assistant
 - https://github.com/cdr/code-server
 type: application
-version: 8.1.3
+version: 8.1.4

--- a/charts/stable/home-assistant/templates/_configmap.tpl
+++ b/charts/stable/home-assistant/templates/_configmap.tpl
@@ -15,10 +15,16 @@ data:
       else
       cat /config/init/recorder.default >> /config/configuration.yaml
       fi
+      if grep -q http: "/config/configuration.yaml"; then
+      echo "configuration.yaml already contains http section"
+      else
+      cat /config/init/http.default >> /config/configuration.yaml
+      fi
     else
     echo "configuration.yaml does NOT exist."
     cp /config/init/configuration.yaml.default /config/configuration.yaml
     cat /config/init/recorder.default >> /config/configuration.yaml
+    cat /config/init/http.default >> /config/configuration.yaml
     fi
   configuration.yaml.default: |-
     # Configure a default setup of Home Assistant (frontend, api, etc)
@@ -39,6 +45,11 @@ data:
       purge_keep_days: 30
       commit_interval: 3
       db_url: {{ ( printf "%s?client_encoding=utf8" ( .Values.postgresql.url.complete | trimAll "\"" ) ) | quote }}
+  http.default: |-
 
+    http:
+      use_x_forwarded_for: true
+      trusted_proxies:
+        - 172.16.0.0/16
 
 {{- end -}}


### PR DESCRIPTION
**Description**
Currently Home Assistant doesn't work with Ingress out of the box.
This at least makes sure ingresses can be used within the default cluster IP ranges.

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
