### PR TITLE
(feat) Add HACS support to Home Assistant

### DIFF
--- a/charts/stable/home-assistant/Chart.yaml
+++ b/charts/stable/home-assistant/Chart.yaml
@@ -29,4 +29,4 @@ sources:
 - https://github.com/home-assistant/home-assistant
 - https://github.com/cdr/code-server
 type: application
-version: 8.1.4
+version: 8.2.0

--- a/charts/stable/home-assistant/SCALE/ix_values.yaml
+++ b/charts/stable/home-assistant/SCALE/ix_values.yaml
@@ -10,8 +10,8 @@ image:
   tag: v2021.10.4@sha256:6f5892e307edd0b135f4ccab1ecee70518e0418b26e6264c23c67d1982eece86
 
 initContainers:
-  init-db:
-    image: "{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
+  init:
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
     command: ["/config/init/init.sh"]
     volumeMounts:
       - name: init

--- a/charts/stable/home-assistant/templates/_configmap.tpl
+++ b/charts/stable/home-assistant/templates/_configmap.tpl
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}-init
 data:
   init.sh: |-
-    #!/bin/sh
+    #!/bin/bash
     if test -f "/config/configuration.yaml"; then
       echo "configuration.yaml exists."
       if grep -q recorder: "/config/configuration.yaml"; then
@@ -37,7 +37,7 @@ data:
     cd "/config/custom_components" || error "Could not change path to /config/custom_components"
 
     info "Downloading HACS"
-    curl -O "https://github.com/hacs/integration/releases/latest/download/hacs.zip" || exit 0
+    wget "https://github.com/hacs/integration/releases/latest/download/hacs.zip" || exit 0
 
     if [ -d "/config/custom_components/hacs" ]; then
         warn "HACS directory already exist, cleaning up..."

--- a/charts/stable/home-assistant/templates/_configmap.tpl
+++ b/charts/stable/home-assistant/templates/_configmap.tpl
@@ -37,7 +37,7 @@ data:
     echo "Downloading HACS"
     wget "https://github.com/hacs/integration/releases/latest/download/hacs.zip" || exit 0
 
-    if -d "/config/custom_components/hacs"; then
+    if [ -d "/config/custom_components/hacs" ]; then
         echo "HACS directory already exist, cleaning up..."
         rm -R "/config/custom_components/hacs"
     fi

--- a/charts/stable/home-assistant/templates/_configmap.tpl
+++ b/charts/stable/home-assistant/templates/_configmap.tpl
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}-init
 data:
   init.sh: |-
-    #!/bin/bash
+    #!/bin/sh
     if test -f "/config/configuration.yaml"; then
       echo "configuration.yaml exists."
       if grep -q recorder: "/config/configuration.yaml"; then
@@ -27,32 +27,30 @@ data:
     cat /config/init/http.default >> /config/configuration.yaml
     fi
 
-    cd "/config" || error "Could not change path to /config"
-    if [ ! -d "/config/custom_components" ]; then
-        info "Creating custom_components directory..."
-        mkdir "/config/custom_components"
-    fi
+    cd "/config" || echo "Could not change path to /config"
+    echo "Creating custom_components directory..."
+    mkdir "/config/custom_components" || echo "custom_components directory already exists"
 
-    info "Changing to the custom_components directory..."
-    cd "/config/custom_components" || error "Could not change path to /config/custom_components"
+    echo "Changing to the custom_components directory..."
+    cd "/config/custom_components" || echo "Could not change path to /config/custom_components"
 
-    info "Downloading HACS"
+    echo "Downloading HACS"
     wget "https://github.com/hacs/integration/releases/latest/download/hacs.zip" || exit 0
 
-    if [ -d "/config/custom_components/hacs" ]; then
-        warn "HACS directory already exist, cleaning up..."
+    if -d "/config/custom_components/hacs"; then
+        echo "HACS directory already exist, cleaning up..."
         rm -R "/config/custom_components/hacs"
     fi
 
-    info "Creating HACS directory..."
+    echo "Creating HACS directory..."
     mkdir "/config/custom_components/hacs"
 
-    info "Unpacking HACS..."
+    echo "Unpacking HACS..."
     unzip "/config/custom_components/hacs.zip" -d "/config/custom_components/hacs" >/dev/null 2>&1
 
-    info "Removing HACS zip file..."
+    echo "Removing HACS zip file..."
     rm "/config/custom_components/hacs.zip"
-    info "Installation complete."
+    echo "Installation complete."
 
   configuration.yaml.default: |-
     # Configure a default setup of Home Assistant (frontend, api, etc)

--- a/charts/stable/home-assistant/templates/_configmap.tpl
+++ b/charts/stable/home-assistant/templates/_configmap.tpl
@@ -26,6 +26,34 @@ data:
     cat /config/init/recorder.default >> /config/configuration.yaml
     cat /config/init/http.default >> /config/configuration.yaml
     fi
+
+    cd "/config" || error "Could not change path to /config"
+    if [ ! -d "/config/custom_components" ]; then
+        info "Creating custom_components directory..."
+        mkdir "/config/custom_components"
+    fi
+
+    info "Changing to the custom_components directory..."
+    cd "/config/custom_components" || error "Could not change path to /config/custom_components"
+
+    info "Downloading HACS"
+    curl -O "https://github.com/hacs/integration/releases/latest/download/hacs.zip" || exit 0
+
+    if [ -d "/config/custom_components/hacs" ]; then
+        warn "HACS directory already exist, cleaning up..."
+        rm -R "/config/custom_components/hacs"
+    fi
+
+    info "Creating HACS directory..."
+    mkdir "/config/custom_components/hacs"
+
+    info "Unpacking HACS..."
+    unzip "/config/custom_components/hacs.zip" -d "/config/custom_components/hacs" >/dev/null 2>&1
+
+    info "Removing HACS zip file..."
+    rm "/config/custom_components/hacs.zip"
+    info "Installation complete."
+
   configuration.yaml.default: |-
     # Configure a default setup of Home Assistant (frontend, api, etc)
     default_config:

--- a/charts/stable/home-assistant/values.yaml
+++ b/charts/stable/home-assistant/values.yaml
@@ -23,8 +23,8 @@ service:
         port: 8123
 
 initContainers:
-  init-db:
-    image: "{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
+  init:
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
     command: ["/config/init/init.sh"]
     volumeMounts:
       - name: init


### PR DESCRIPTION
**Description**
This PR adds installing HACS to the Home Assistant installation during init, for added convenience

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
To prevent restarts being broken by not being able to download the HACS files, it does `exist 0` if the download was not able to be succeeded.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
