### PR TITLE
fix(Logitech Media Server): Fix service name casing in questions.yaml

### DIFF
--- a/charts/incubator/logitech-media-server/Chart.yaml
+++ b/charts/incubator/logitech-media-server/Chart.yaml
@@ -26,4 +26,4 @@ sources:
 - https://github.com/Logitech/slimserver
 - https://hub.docker.com/r/lmscommunity/logitechmediaserver
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/charts/incubator/logitech-media-server/SCALE/questions.yaml
+++ b/charts/incubator/logitech-media-server/SCALE/questions.yaml
@@ -351,7 +351,7 @@ questions:
                               type: int
                               min: 9000
                               max: 65535
-        - variable: playerUdp
+        - variable: playerudp
           label: "Logitech Media Server Player Communcation"
           description: "Logitech Media Server Player Service for UDP communication"
           schema:


### PR DESCRIPTION
**Description**

Uppercase character in service names is not allowed.
Questions.yaml, contained 1 upporcase variable name for a service.

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**


**Notes:**

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
