### PR TITLE
feat(common): simplify postgresql url generator

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.3.6
+version: 8.3.7

--- a/charts/library/common/templates/lib/dependencies/_postgresInjector.tpl
+++ b/charts/library/common/templates/lib/dependencies/_postgresInjector.tpl
@@ -23,7 +23,8 @@ data:
   postgresql-password: {{ $dbPass | b64enc | quote }}
   postgresql-postgres-password: {{ randAlphaNum 50 | b64enc | quote }}
 {{- end }}
-  url: {{ ( printf "%v%v:%v@%v-%v:%v/%v" "postgresql://" .Values.postgresql.postgresqlUsername $dbPass .Release.Name "postgresql" "5432" .Values.postgresql.postgresqlDatabase  ) | b64enc | quote }}
+  url: {{ ( printf "postgresql://%v:%v@%v-postgresql:5432/%v" .Values.postgresql.postgresqlUsername $dbPass .Release.Name .Values.postgresql.postgresqlDatabase  ) | b64enc | quote }}
+  urlnossl: {{ ( printf "postgresql://%v:%v@%v-postgresql:5432/%v?sslmode=disable" .Values.postgresql.postgresqlUsername $dbPass .Release.Name .Values.postgresql.postgresqlDatabase  ) | b64enc | quote }}
   plainporthost: {{ ( printf "%v-%v" .Release.Name "postgresql" ) | b64enc | quote }}
   plainhost: {{ ( printf "%v-%v" .Release.Name "postgresql" ) | b64enc | quote }}
 type: Opaque


### PR DESCRIPTION
**Description**
Currently the generator for postgresql url's in common is a bit long and convoluted, this should simplify it a bit.
Also adds an option to reference a non-ssl url variant

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
