### PR TITLE
fix(Logitech Media Server): Add expected mount paths

### DIFF
--- a/charts/incubator/logitech-media-server/Chart.yaml
+++ b/charts/incubator/logitech-media-server/Chart.yaml
@@ -26,4 +26,4 @@ sources:
 - https://github.com/Logitech/slimserver
 - https://hub.docker.com/r/lmscommunity/logitechmediaserver
 type: application
-version: 1.1.0
+version: 1.0.4

--- a/charts/incubator/logitech-media-server/Chart.yaml
+++ b/charts/incubator/logitech-media-server/Chart.yaml
@@ -26,4 +26,4 @@ sources:
 - https://github.com/Logitech/slimserver
 - https://hub.docker.com/r/lmscommunity/logitechmediaserver
 type: application
-version: 1.0.3
+version: 1.1.0

--- a/charts/incubator/logitech-media-server/SCALE/questions.yaml
+++ b/charts/incubator/logitech-media-server/SCALE/questions.yaml
@@ -576,6 +576,226 @@ questions:
                   show_if: [["type", "=", "pvc"]]
                   type: string
                   default: "100Gi"
+        - variable: playlist
+          label: "App Playlist Storage"
+          description: "Location where to get and store the saved playlists."
+          schema:
+            type: dict
+            attrs:
+              - variable: enabled
+                label: "Enable the storage"
+                schema:
+                  type: boolean
+                  default: true
+              - variable: type
+                label: "(Advanced) Type of Storage"
+                description: "Sets the persistence type"
+                schema:
+                  type: string
+                  default: "emptyDir"
+                  enum:
+                    - value: "pvc"
+                      description: "pvc"
+                    - value: "emptyDir"
+                      description: "emptyDir"
+                    - value: "hostPath"
+                      description: "hostPath"
+              - variable: storageClass
+                label: "(Advanced) storageClass"
+                description: " Warning: Anything other than SCALE-ZFS will break rollback!"
+                schema:
+                  show_if: [["type", "=", "pvc"]]
+                  type: string
+                  default: "SCALE-ZFS"
+              - variable: setPermissions
+                label: "Automatic Permissions"
+                description: "Automatically set permissions on install"
+                schema:
+                  show_if: [["type", "=", "hostPath"]]
+                  type: boolean
+                  default: true
+              - variable: readOnly
+                label: "readOnly"
+                schema:
+                  type: boolean
+                  default: false
+              - variable: hostPath
+                label: "hostPath"
+                description: "Path inside the container the storage is mounted"
+                schema:
+                  show_if: [["type", "=", "hostPath"]]
+                  type: hostpath
+              - variable: hostPathType
+                label: "hostPath Type"
+                schema:
+                  show_if: [["type", "=", "hostPath"]]
+                  type: string
+                  default: ""
+                  enum:
+                    - value: ""
+                      description: "Default"
+                    - value: "DirectoryOrCreate"
+                      description: "DirectoryOrCreate"
+                    - value: "Directory"
+                      description: "Directory"
+                    - value: "FileOrCreate"
+                      description: "FileOrCreate"
+                    - value: "File"
+                      description: "File"
+                    - value: "Socket"
+                      description: "Socket"
+                    - value: "CharDevice"
+                      description: "CharDevice"
+                    - value: "BlockDevice"
+                      description: "BlockDevice"
+              - variable: mountPath
+                label: "mountPath"
+                description: "Path inside the container the storage is mounted"
+                schema:
+                  type: string
+                  default: "/playlist"
+                  hidden: true
+              - variable: medium
+                label: "EmptyDir Medium"
+                schema:
+                  show_if: [["type", "=", "emptyDir"]]
+                  type: string
+                  default: ""
+                  enum:
+                    - value: ""
+                      description: "Default"
+                    - value: "Memory"
+                      description: "Memory"
+              - variable: accessMode
+                label: "Access Mode (Advanced)"
+                description: "Allow or disallow multiple PVC's writhing to the same PV"
+                schema:
+                  show_if: [["type", "=", "pvc"]]
+                  type: string
+                  default: "ReadWriteOnce"
+                  enum:
+                    - value: "ReadWriteOnce"
+                      description: "ReadWriteOnce"
+                    - value: "ReadOnlyMany"
+                      description: "ReadOnlyMany"
+                    - value: "ReadWriteMany"
+                      description: "ReadWriteMany"
+              - variable: size
+                label: "Size quotum of storage"
+                schema:
+                  show_if: [["type", "=", "pvc"]]
+                  type: string
+                  default: "100Gi"
+        - variable: music
+          label: "App Music Library"
+          description: "Location where to get the music library."
+          schema:
+            type: dict
+            attrs:
+              - variable: enabled
+                label: "Enable the storage"
+                schema:
+                  type: boolean
+                  default: true
+              - variable: type
+                label: "(Advanced) Type of Storage"
+                description: "Sets the persistence type"
+                schema:
+                  type: string
+                  default: "emptyDir"
+                  enum:
+                    - value: "pvc"
+                      description: "pvc"
+                    - value: "emptyDir"
+                      description: "emptyDir"
+                    - value: "hostPath"
+                      description: "hostPath"
+              - variable: storageClass
+                label: "(Advanced) storageClass"
+                description: " Warning: Anything other than SCALE-ZFS will break rollback!"
+                schema:
+                  show_if: [["type", "=", "pvc"]]
+                  type: string
+                  default: "SCALE-ZFS"
+              - variable: setPermissions
+                label: "Automatic Permissions"
+                description: "Automatically set permissions on install"
+                schema:
+                  show_if: [["type", "=", "hostPath"]]
+                  type: boolean
+                  default: true
+              - variable: readOnly
+                label: "readOnly"
+                schema:
+                  type: boolean
+                  default: true
+              - variable: hostPath
+                label: "hostPath"
+                description: "Path inside the container the storage is mounted"
+                schema:
+                  show_if: [["type", "=", "hostPath"]]
+                  type: hostpath
+              - variable: hostPathType
+                label: "hostPath Type"
+                schema:
+                  show_if: [["type", "=", "hostPath"]]
+                  type: string
+                  default: ""
+                  enum:
+                    - value: ""
+                      description: "Default"
+                    - value: "DirectoryOrCreate"
+                      description: "DirectoryOrCreate"
+                    - value: "Directory"
+                      description: "Directory"
+                    - value: "FileOrCreate"
+                      description: "FileOrCreate"
+                    - value: "File"
+                      description: "File"
+                    - value: "Socket"
+                      description: "Socket"
+                    - value: "CharDevice"
+                      description: "CharDevice"
+                    - value: "BlockDevice"
+                      description: "BlockDevice"
+              - variable: mountPath
+                label: "mountPath"
+                description: "Path inside the container the storage is mounted"
+                schema:
+                  type: string
+                  default: "/music"
+                  hidden: true
+              - variable: medium
+                label: "EmptyDir Medium"
+                schema:
+                  show_if: [["type", "=", "emptyDir"]]
+                  type: string
+                  default: ""
+                  enum:
+                    - value: ""
+                      description: "Default"
+                    - value: "Memory"
+                      description: "Memory"
+              - variable: accessMode
+                label: "Access Mode (Advanced)"
+                description: "Allow or disallow multiple PVC's writhing to the same PV"
+                schema:
+                  show_if: [["type", "=", "pvc"]]
+                  type: string
+                  default: "ReadWriteOnce"
+                  enum:
+                    - value: "ReadWriteOnce"
+                      description: "ReadWriteOnce"
+                    - value: "ReadOnlyMany"
+                      description: "ReadOnlyMany"
+                    - value: "ReadWriteMany"
+                      description: "ReadWriteMany"
+              - variable: size
+                label: "Size quotum of storage"
+                schema:
+                  show_if: [["type", "=", "pvc"]]
+                  type: string
+                  default: "100Gi"
 
 # Include{persistenceList}
 

--- a/charts/incubator/logitech-media-server/SCALE/questions.yaml
+++ b/charts/incubator/logitech-media-server/SCALE/questions.yaml
@@ -592,7 +592,7 @@ questions:
                 description: "Sets the persistence type"
                 schema:
                   type: string
-                  default: "emptyDir"
+                  default: "hostPath"
                   enum:
                     - value: "pvc"
                       description: "pvc"
@@ -702,7 +702,7 @@ questions:
                 description: "Sets the persistence type"
                 schema:
                   type: string
-                  default: "emptyDir"
+                  default: "hostPath"
                   enum:
                     - value: "pvc"
                       description: "pvc"

--- a/charts/incubator/logitech-media-server/values.yaml
+++ b/charts/incubator/logitech-media-server/values.yaml
@@ -53,12 +53,3 @@ persistence:
     type: pvc
     accessMode: ReadWriteOnce
     size: "100Gi"
-  playlist:
-    enabled: true
-    mounthPath: "/playlist"
-    type: hostPath
-  music:
-    enabled: true
-    mountPath: "/music"
-    type: hostPath
-    readOnly: true

--- a/charts/incubator/logitech-media-server/values.yaml
+++ b/charts/incubator/logitech-media-server/values.yaml
@@ -53,3 +53,12 @@ persistence:
     type: pvc
     accessMode: ReadWriteOnce
     size: "100Gi"
+  playlist:
+    enabled: true
+    mounthPath: "/playlist"
+    type: emptyDir
+  music:
+    enabled: true
+    mountPath: "/music"
+    type: emptyDir
+    readOnly: true

--- a/charts/incubator/logitech-media-server/values.yaml
+++ b/charts/incubator/logitech-media-server/values.yaml
@@ -56,9 +56,9 @@ persistence:
   playlist:
     enabled: true
     mounthPath: "/playlist"
-    type: emptyDir
+    type: hostPath
   music:
     enabled: true
     mountPath: "/music"
-    type: emptyDir
+    type: hostPath
     readOnly: true


### PR DESCRIPTION
**Description**

The container expects the music library to be mounted on '/music' and the playlists to be mounted on '/playlist'.
This feature adds these mountPaths by default using empty dir to suggest the user to provide them.

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**

**Notes:**


**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
