### PR TITLE
fix(common): Just provide warning when chmod fails on autopermissions

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.3.9
+version: 8.3.10

--- a/charts/library/common/templates/lib/controller/_autopermissions.yaml
+++ b/charts/library/common/templates/lib/controller/_autopermissions.yaml
@@ -22,7 +22,7 @@ before chart installation.
   command:
     - "/bin/sh"
     - "-c"
-    - "echo 'Automatically correcting permissions...';{{ if and ( .Values.addons.vpn.configFile.enabled ) ( not ( eq .Values.addons.vpn.type "disabled" )) }}chown -R 568:568 /vpn/vpn.conf; chmod -R g+w /vpn/vpn.conf;{{ end }}{{ range $_, $hpm := $hostPathMounts }}chown -R :{{ $group }} {{ $hpm.mountPath | squote }}; chmod -R g+w {{ $hpm.mountPath | squote }};{{ end }}"
+    - "echo 'Automatically correcting permissions...';{{ if and ( .Values.addons.vpn.configFile.enabled ) ( not ( eq .Values.addons.vpn.type "disabled" )) }}chown -R 568:568 /vpn/vpn.conf; chmod -R g+w /vpn/vpn.conf || echo "chmod failed for vpn config, are you running NFSv4 ACLs?";{{ end }}{{ range $_, $hpm := $hostPathMounts }}chown -R :{{ $group }} {{ $hpm.mountPath | squote }}; chmod -R g+w || echo "chmod failed for {{ $hpm.mountPath }}, are you running NFSv4 ACLs?" {{ $hpm.mountPath | squote }};{{ end }}"
   volumeMounts:
     {{- if and ( .Values.addons.vpn.configFile.enabled ) ( not ( eq .Values.addons.vpn.type "disabled" )) }}
     - name: vpnconfig

--- a/charts/library/common/templates/lib/controller/_autopermissions.yaml
+++ b/charts/library/common/templates/lib/controller/_autopermissions.yaml
@@ -22,7 +22,7 @@ before chart installation.
   command:
     - "/bin/sh"
     - "-c"
-    - "echo 'Automatically correcting permissions...';{{ if and ( .Values.addons.vpn.configFile.enabled ) ( not ( eq .Values.addons.vpn.type "disabled" )) }}chown -R 568:568 /vpn/vpn.conf; chmod -R g+w /vpn/vpn.conf || echo "chmod failed for vpn config, are you running NFSv4 ACLs?";{{ end }}{{ range $_, $hpm := $hostPathMounts }}chown -R :{{ $group }} {{ $hpm.mountPath | squote }}; chmod -R g+w || echo "chmod failed for {{ $hpm.mountPath }}, are you running NFSv4 ACLs?" {{ $hpm.mountPath | squote }};{{ end }}"
+    - "echo 'Automatically correcting permissions...';{{ if and ( .Values.addons.vpn.configFile.enabled ) ( not ( eq .Values.addons.vpn.type "disabled" )) }}chown -R 568:568 /vpn/vpn.conf; chmod -R g+w /vpn/vpn.conf || echo 'chmod failed for vpn config, are you running NFSv4 ACLs?';{{ end }}{{ range $_, $hpm := $hostPathMounts }}chown -R :{{ $group }} {{ $hpm.mountPath | squote }}; chmod -R g+w || echo 'chmod failed for {{ $hpm.mountPath }}, are you running NFSv4 ACLs?' {{ $hpm.mountPath | squote }};{{ end }}"
   volumeMounts:
     {{- if and ( .Values.addons.vpn.configFile.enabled ) ( not ( eq .Values.addons.vpn.type "disabled" )) }}
     - name: vpnconfig

--- a/tests/library/common/autoPermissions_spec.rb
+++ b/tests/library/common/autoPermissions_spec.rb
@@ -131,7 +131,7 @@ class Test < ChartTest
 
       it 'can process default (568:568) permissions for multiple volumes' do
         results= {
-          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :666 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
+          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :568 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :568 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
         }
         values = {
           persistenceList: [
@@ -161,7 +161,7 @@ class Test < ChartTest
 
       it 'outputs default permissions with irrelevant podSecurityContext' do
         results= {
-          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :666 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
+          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :568 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :568 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
         }
         values = {
           podSecurityContext: {
@@ -223,7 +223,7 @@ class Test < ChartTest
 
       it 'outputs runAsUser permissions for multiple volumes when set' do
         results= {
-          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :666 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
+          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :568 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :568 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
         }
         values = {
           podSecurityContext: {

--- a/tests/library/common/autoPermissions_spec.rb
+++ b/tests/library/common/autoPermissions_spec.rb
@@ -131,7 +131,7 @@ class Test < ChartTest
 
       it 'can process default (568:568) permissions for multiple volumes' do
         results= {
-          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :568 '/configlist'; chmod -R g+w '/configlist';chown -R :568 '/data'; chmod -R g+w '/data';"]
+          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :666 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
         }
         values = {
           persistenceList: [
@@ -161,7 +161,8 @@ class Test < ChartTest
 
       it 'outputs default permissions with irrelevant podSecurityContext' do
         results= {
-          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :568 '/configlist'; chmod -R g+w '/configlist';chown -R :568 '/data'; chmod -R g+w '/data';"]
+          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :666 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
+                   ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :666 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
         }
         values = {
           podSecurityContext: {
@@ -192,7 +193,7 @@ class Test < ChartTest
 
       it 'outputs fsgroup permissions for multiple volumes when set' do
         results= {
-          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w '/configlist';chown -R :666 '/data'; chmod -R g+w '/data';"]
+          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :666 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
         }
         values = {
           podSecurityContext: {
@@ -223,7 +224,7 @@ class Test < ChartTest
 
       it 'outputs runAsUser permissions for multiple volumes when set' do
         results= {
-          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :568 '/configlist'; chmod -R g+w '/configlist';chown -R :568 '/data'; chmod -R g+w '/data';"]
+          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :666 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
         }
         values = {
           podSecurityContext: {
@@ -254,7 +255,7 @@ class Test < ChartTest
 
       it 'outputs fsGroup AND runAsUser permissions for multiple volumes when both are set' do
         results= {
-          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w '/configlist';chown -R :666 '/data'; chmod -R g+w '/data';"]
+          command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :666 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
         }
         values = {
           podSecurityContext: {

--- a/tests/library/common/autoPermissions_spec.rb
+++ b/tests/library/common/autoPermissions_spec.rb
@@ -162,7 +162,6 @@ class Test < ChartTest
       it 'outputs default permissions with irrelevant podSecurityContext' do
         results= {
           command: ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :666 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
-                   ["/bin/sh", "-c", "echo 'Automatically correcting permissions...';chown -R :666 '/configlist'; chmod -R g+w || echo 'chmod failed for /configlist, are you running NFSv4 ACLs?' '/configlist';chown -R :666 '/data'; chmod -R g+w || echo 'chmod failed for /data, are you running NFSv4 ACLs?' '/data';"]
         }
         values = {
           podSecurityContext: {


### PR DESCRIPTION
**Description**
When running nfsv4 ACL's autopermissions always fail due to CHMOD failing.
This should spawn an error and `exit 0` instead of breaking app deployment.

We should, in the future, create custom scripting to also handle the different ACL/permission types neatly.

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
