### PR TITLE
fix(home-assistant): Fix invisible items in Automation Dashboard

### DIFF
--- a/charts/stable/home-assistant/Chart.yaml
+++ b/charts/stable/home-assistant/Chart.yaml
@@ -29,4 +29,4 @@ sources:
 - https://github.com/home-assistant/home-assistant
 - https://github.com/cdr/code-server
 type: application
-version: 8.2.2
+version: 8.2.3

--- a/charts/stable/home-assistant/templates/_configmap.tpl
+++ b/charts/stable/home-assistant/templates/_configmap.tpl
@@ -27,6 +27,16 @@ data:
     cat /config/init/http.default >> /config/configuration.yaml
     fi
 
+    echo "Creating include files..."
+    for include_file in groups.yaml automations.yaml scripts.yaml scenes.yaml; do
+      if test -f "/config/$include_file"; then
+      echo "$include_file exists."
+      else
+      echo "$include_file does NOT exist."
+      touch "/config/$include_file"
+      fi
+    done
+
     cd "/config" || echo "Could not change path to /config"
     echo "Creating custom_components directory..."
     mkdir "/config/custom_components" || echo "custom_components directory already exists"

--- a/charts/stable/home-assistant/templates/_configmap.tpl
+++ b/charts/stable/home-assistant/templates/_configmap.tpl
@@ -60,11 +60,10 @@ data:
     tts:
       - platform: google_translate
 
-    # Example Includes
-    # group: !include groups.yaml
-    # automation: !include automations.yaml
-    # script: !include scripts.yaml
-    # scene: !include scenes.yaml
+    group: !include groups.yaml
+    automation: !include automations.yaml
+    script: !include scripts.yaml
+    scene: !include scenes.yaml
   recorder.default: |-
 
     recorder:


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Automations are missing from GUI because `configurations.yaml` does not include the files Home Assistant references for automations. The same is true for groups, scripts, and scenes. While Home Assistant is able to write to the files, it's not able to read the same files to populate the GUI.

Address issues with #1162 by creating the include files if they do not exist. 

Fixes #1161 

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Tested by installing chart to local Kubernetes cluster in both clean and upgrade modes.

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
