### PR TITLE
feat(common): set SCALE-ZFS as a default storageClassName for SCALE when nothing is given

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.3.10
+version: 8.3.11

--- a/charts/library/common/templates/_statefulset.tpl
+++ b/charts/library/common/templates/_statefulset.tpl
@@ -64,6 +64,8 @@ spec:
             storage: {{ required (printf "size is required for PVC %v" $vct.name) $vct.size | quote }}
         {{- if $vct.storageClass }}
         storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else if (eq "SCALE-ZFS" $vct.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" $releaseName ) }}{{- else }}{{ $vct.storageClass | quote }}{{- end }}
+        {{- else if .Values.ixChartContext }}
+        storageClassName: {{ printf "%v-%v"  "ix-storage-class" .Release.Name }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/library/common/templates/classes/_pvc.tpl
+++ b/charts/library/common/templates/classes/_pvc.tpl
@@ -45,6 +45,8 @@ spec:
       storage: {{ $values.size | default "100Gi" | quote }}
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
+  {{- else if .Values.ixChartContext }}
+  storageClassName: {{ printf "%v-%v"  "ix-storage-class" .Release.Name }}
   {{- end }}
   {{- if $values.volumeName }}
   volumeName: {{ $values.volumeName | quote }}


### PR DESCRIPTION
**Description**
Currently we need to override the storageclass on SCALE with "SCALE-ZFS" to use the SCALE default storageClass.
This is a bit... odd and generally inefficient. We should just allow a default (blank) storageClass and inject the SCALE storageClass when we detect someone is using SCALE by checking existence of the values SCALE injects into values.yaml

This also means we don't have to explicitly set the storageClass in ix_values.yaml when we use our own Apps as a dependency.

**Type of change**

- [X] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
