### PR TITLE
fix(Postgresql): use correct PVC storageClass when using postgresql as a dependency on SCALE

### DIFF
--- a/charts/incubator/amcrest2mqtt/questions.yaml
+++ b/charts/incubator/amcrest2mqtt/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/apache-musicindex/questions.yaml
+++ b/charts/incubator/apache-musicindex/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/aria2/questions.yaml
+++ b/charts/incubator/aria2/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/audacity/questions.yaml
+++ b/charts/incubator/audacity/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/babybuddy/questions.yaml
+++ b/charts/incubator/babybuddy/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/beets/questions.yaml
+++ b/charts/incubator/beets/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/cloud9/questions.yaml
+++ b/charts/incubator/cloud9/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/code-server/questions.yaml
+++ b/charts/incubator/code-server/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/cryptofolio/questions.yaml
+++ b/charts/incubator/cryptofolio/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/davos/questions.yaml
+++ b/charts/incubator/davos/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/digikam/questions.yaml
+++ b/charts/incubator/digikam/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/doublecommander/questions.yaml
+++ b/charts/incubator/doublecommander/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/dsmr-reader/questions.yaml
+++ b/charts/incubator/dsmr-reader/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/etherpad/questions.yaml
+++ b/charts/incubator/etherpad/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/filezilla/questions.yaml
+++ b/charts/incubator/filezilla/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/firefox-syncserver/questions.yaml
+++ b/charts/incubator/firefox-syncserver/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/fossil/questions.yaml
+++ b/charts/incubator/fossil/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/golinks/questions.yaml
+++ b/charts/incubator/golinks/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/gotify/questions.yaml
+++ b/charts/incubator/gotify/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/grav/questions.yaml
+++ b/charts/incubator/grav/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/headphones/questions.yaml
+++ b/charts/incubator/headphones/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/icantbelieveitsnotvaletudo/questions.yaml
+++ b/charts/incubator/icantbelieveitsnotvaletudo/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/joplin-server/questions.yaml
+++ b/charts/incubator/joplin-server/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/kanboard/questions.yaml
+++ b/charts/incubator/kanboard/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/leaf2mqtt/questions.yaml
+++ b/charts/incubator/leaf2mqtt/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/librespeed/questions.yaml
+++ b/charts/incubator/librespeed/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/logitech-media-server/questions.yaml
+++ b/charts/incubator/logitech-media-server/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/medusa/questions.yaml
+++ b/charts/incubator/medusa/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/miniflux/questions.yaml
+++ b/charts/incubator/miniflux/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/minio-console/questions.yaml
+++ b/charts/incubator/minio-console/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/mstream/questions.yaml
+++ b/charts/incubator/mstream/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/muximux/questions.yaml
+++ b/charts/incubator/muximux/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/notes/questions.yaml
+++ b/charts/incubator/notes/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/novnc/questions.yaml
+++ b/charts/incubator/novnc/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/odoo/questions.yaml
+++ b/charts/incubator/odoo/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/openkm/questions.yaml
+++ b/charts/incubator/openkm/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/photoshow/questions.yaml
+++ b/charts/incubator/photoshow/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/piwigo/questions.yaml
+++ b/charts/incubator/piwigo/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/pixapop/questions.yaml
+++ b/charts/incubator/pixapop/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/recipes/questions.yaml
+++ b/charts/incubator/recipes/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/remmina/questions.yaml
+++ b/charts/incubator/remmina/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/shiori/questions.yaml
+++ b/charts/incubator/shiori/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/shorturl/questions.yaml
+++ b/charts/incubator/shorturl/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/sickchill/questions.yaml
+++ b/charts/incubator/sickchill/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/sickgear/questions.yaml
+++ b/charts/incubator/sickgear/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/smokeping/questions.yaml
+++ b/charts/incubator/smokeping/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/sqlitebrowser/questions.yaml
+++ b/charts/incubator/sqlitebrowser/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/static/questions.yaml
+++ b/charts/incubator/static/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/statping/questions.yaml
+++ b/charts/incubator/statping/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/tdarr-node/questions.yaml
+++ b/charts/incubator/tdarr-node/questions.yaml
@@ -15,6 +15,7 @@ questions:
             editable: false
             type: boolean
             default: false
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/tdarr/questions.yaml
+++ b/charts/incubator/tdarr/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: false
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/teedy/questions.yaml
+++ b/charts/incubator/teedy/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/traccar/questions.yaml
+++ b/charts/incubator/traccar/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/tt-rss/questions.yaml
+++ b/charts/incubator/tt-rss/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/twtxt/questions.yaml
+++ b/charts/incubator/twtxt/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/uptime-kuma/questions.yaml
+++ b/charts/incubator/uptime-kuma/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/valheim/questions.yaml
+++ b/charts/incubator/valheim/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/whoogle/questions.yaml
+++ b/charts/incubator/whoogle/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/wiki/questions.yaml
+++ b/charts/incubator/wiki/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/wikijs/questions.yaml
+++ b/charts/incubator/wikijs/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/incubator/zigbee2mqtt/questions.yaml
+++ b/charts/incubator/zigbee2mqtt/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.3.13
+version: 8.3.14

--- a/charts/library/common/templates/classes/_pvc.tpl
+++ b/charts/library/common/templates/classes/_pvc.tpl
@@ -45,8 +45,8 @@ spec:
       storage: {{ $values.size | default "100Gi" | quote }}
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
-  {{- else if .Values.ixChartContext }}
-  storageClassName: {{ printf "%v-%v"  "ix-storage-class" .Release.Name }}
+  {{- else if $.Values.global.isSCALE }}
+  storageClassName: {{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}
   {{- end }}
   {{- if $values.volumeName }}
   volumeName: {{ $values.volumeName | quote }}

--- a/charts/library/common/templates/lib/dependencies/_postgresInjector.tpl
+++ b/charts/library/common/templates/lib/dependencies/_postgresInjector.tpl
@@ -3,6 +3,7 @@ This template generates a random password and ensures it persists across updates
 */}}
 {{- define "common.dependencies.postgresql.injector" -}}
 {{- $pghost := printf "%v-%v" .Release.Name "postgresql" }}
+
 {{- if .Values.postgresql.enabled }}
 ---
 apiVersion: v1
@@ -36,13 +37,6 @@ type: Opaque
 {{- $_ := set .Values.postgresql.url "plainporthost" ( ( printf "%v-%v:5432" .Release.Name "postgresql" ) | quote ) }}
 {{- $_ := set .Values.postgresql.url "complete" ( ( printf "postgresql://%v:%v@%v-postgresql:5432/%v" .Values.postgresql.postgresqlUsername $dbPass .Release.Name .Values.postgresql.postgresqlDatabase  ) | quote ) }}
 {{- $_ := set .Values.postgresql.url "jdbc" ( ( printf "jdbc:postgresql://%v-postgresql:5432/%v" .Release.Name .Values.postgresql.postgresqlDatabase  ) | quote ) }}
-
-{{/*
-Also inject the storageClassName into the child chart
-*/}}
-{{- if .Values.ixChartContext }}
-{{- $_ := set .Values.postgresql "ixChartContext" ( dict "storageClassName" ".Values.ixChartContext.storageClassName" ) }}
-{{- end }}
 
 {{- end }}
 {{- end -}}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -74,6 +74,7 @@ global:
   nameOverride:
   # -- Set the entire name definition
   fullnameOverride:
+  isSCALE: false
 
 controller:
   # -- enable the controller.

--- a/charts/stable/airsonic/questions.yaml
+++ b/charts/stable/airsonic/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/appdaemon/questions.yaml
+++ b/charts/stable/appdaemon/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/authelia/questions.yaml
+++ b/charts/stable/authelia/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/bazarr/questions.yaml
+++ b/charts/stable/bazarr/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/booksonic-air/questions.yaml
+++ b/charts/stable/booksonic-air/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/calibre-web/questions.yaml
+++ b/charts/stable/calibre-web/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/calibre/questions.yaml
+++ b/charts/stable/calibre/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/collabora-online/questions.yaml
+++ b/charts/stable/collabora-online/questions.yaml
@@ -24,6 +24,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/custom-app/questions.yaml
+++ b/charts/stable/custom-app/questions.yaml
@@ -55,6 +55,7 @@ questions:
               - value: "Never"
                 description: "Never"
 
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/deconz/questions.yaml
+++ b/charts/stable/deconz/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/deepstack-cpu/questions.yaml
+++ b/charts/stable/deepstack-cpu/questions.yaml
@@ -24,6 +24,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/deepstack-gpu/questions.yaml
+++ b/charts/stable/deepstack-gpu/questions.yaml
@@ -24,6 +24,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/deluge/questions.yaml
+++ b/charts/stable/deluge/questions.yaml
@@ -24,6 +24,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/dizquetv/questions.yaml
+++ b/charts/stable/dizquetv/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/duplicati/questions.yaml
+++ b/charts/stable/duplicati/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/emby/questions.yaml
+++ b/charts/stable/emby/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/esphome/questions.yaml
+++ b/charts/stable/esphome/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/external-service/questions.yaml
+++ b/charts/stable/external-service/questions.yaml
@@ -23,7 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
-
+# Include{global}
   - variable: service
     group: "Networking and Services"
     label: "Configure Service(s)"

--- a/charts/stable/fireflyiii/questions.yaml
+++ b/charts/stable/fireflyiii/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/flaresolverr/questions.yaml
+++ b/charts/stable/flaresolverr/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/flood/questions.yaml
+++ b/charts/stable/flood/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/focalboard/questions.yaml
+++ b/charts/stable/focalboard/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/freeradius/questions.yaml
+++ b/charts/stable/freeradius/questions.yaml
@@ -15,6 +15,7 @@ questions:
             editable: false
             type: boolean
             default: false
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/freshrss/questions.yaml
+++ b/charts/stable/freshrss/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/gaps/questions.yaml
+++ b/charts/stable/gaps/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/gitea/questions.yaml
+++ b/charts/stable/gitea/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/gonic/questions.yaml
+++ b/charts/stable/gonic/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/grocy/questions.yaml
+++ b/charts/stable/grocy/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/handbrake/questions.yaml
+++ b/charts/stable/handbrake/questions.yaml
@@ -24,6 +24,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/haste-server/questions.yaml
+++ b/charts/stable/haste-server/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/healthchecks/questions.yaml
+++ b/charts/stable/healthchecks/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/heimdall/questions.yaml
+++ b/charts/stable/heimdall/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/home-assistant/questions.yaml
+++ b/charts/stable/home-assistant/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/hyperion-ng/questions.yaml
+++ b/charts/stable/hyperion-ng/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/jackett/questions.yaml
+++ b/charts/stable/jackett/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/jdownloader2/questions.yaml
+++ b/charts/stable/jdownloader2/questions.yaml
@@ -24,6 +24,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/jellyfin/questions.yaml
+++ b/charts/stable/jellyfin/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/k8s-gateway/questions.yaml
+++ b/charts/stable/k8s-gateway/questions.yaml
@@ -15,6 +15,7 @@ questions:
             editable: false
             type: boolean
             default: false
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/kms/questions.yaml
+++ b/charts/stable/kms/questions.yaml
@@ -15,6 +15,7 @@ questions:
             editable: false
             type: boolean
             default: false
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/komga/questions.yaml
+++ b/charts/stable/komga/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/lazylibrarian/questions.yaml
+++ b/charts/stable/lazylibrarian/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/librespeed/questions.yaml
+++ b/charts/stable/librespeed/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/lidarr/questions.yaml
+++ b/charts/stable/lidarr/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/littlelink/questions.yaml
+++ b/charts/stable/littlelink/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/lychee/questions.yaml
+++ b/charts/stable/lychee/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/mealie/questions.yaml
+++ b/charts/stable/mealie/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/mosquitto/questions.yaml
+++ b/charts/stable/mosquitto/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/mylar/questions.yaml
+++ b/charts/stable/mylar/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/navidrome/questions.yaml
+++ b/charts/stable/navidrome/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/nextcloud/questions.yaml
+++ b/charts/stable/nextcloud/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/node-red/questions.yaml
+++ b/charts/stable/node-red/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/nullserv/questions.yaml
+++ b/charts/stable/nullserv/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/nzbget/questions.yaml
+++ b/charts/stable/nzbget/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/nzbhydra/questions.yaml
+++ b/charts/stable/nzbhydra/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/octoprint/questions.yaml
+++ b/charts/stable/octoprint/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/omada-controller/questions.yaml
+++ b/charts/stable/omada-controller/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/ombi/questions.yaml
+++ b/charts/stable/ombi/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/onlyoffice-document-server/questions.yaml
+++ b/charts/stable/onlyoffice-document-server/questions.yaml
@@ -25,6 +25,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/openldap/questions.yaml
+++ b/charts/stable/openldap/questions.yaml
@@ -15,6 +15,7 @@ questions:
             editable: false
             type: boolean
             default: false
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/organizr/questions.yaml
+++ b/charts/stable/organizr/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/oscam/questions.yaml
+++ b/charts/stable/oscam/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/overseerr/questions.yaml
+++ b/charts/stable/overseerr/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/owncast/questions.yaml
+++ b/charts/stable/owncast/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/owncloud-ocis/questions.yaml
+++ b/charts/stable/owncloud-ocis/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/pgadmin/questions.yaml
+++ b/charts/stable/pgadmin/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/photoprism/questions.yaml
+++ b/charts/stable/photoprism/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/phpldapadmin/questions.yaml
+++ b/charts/stable/phpldapadmin/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/piaware/questions.yaml
+++ b/charts/stable/piaware/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/pihole/questions.yaml
+++ b/charts/stable/pihole/questions.yaml
@@ -32,6 +32,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/plex/questions.yaml
+++ b/charts/stable/plex/questions.yaml
@@ -24,6 +24,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/podgrab/questions.yaml
+++ b/charts/stable/podgrab/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/postgresql/questions.yaml
+++ b/charts/stable/postgresql/questions.yaml
@@ -15,6 +15,7 @@ questions:
             editable: false
             type: boolean
             default: false
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/pretend-youre-xyzzy/questions.yaml
+++ b/charts/stable/pretend-youre-xyzzy/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/protonmail-bridge/questions.yaml
+++ b/charts/stable/protonmail-bridge/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/prowlarr/questions.yaml
+++ b/charts/stable/prowlarr/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/pyload/questions.yaml
+++ b/charts/stable/pyload/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/qbittorrent/questions.yaml
+++ b/charts/stable/qbittorrent/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/radarr/questions.yaml
+++ b/charts/stable/radarr/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/readarr/questions.yaml
+++ b/charts/stable/readarr/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/reg/questions.yaml
+++ b/charts/stable/reg/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/resilio-sync/questions.yaml
+++ b/charts/stable/resilio-sync/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/sabnzbd/questions.yaml
+++ b/charts/stable/sabnzbd/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/ser2sock/questions.yaml
+++ b/charts/stable/ser2sock/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/sonarr/questions.yaml
+++ b/charts/stable/sonarr/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/stash/questions.yaml
+++ b/charts/stable/stash/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/syncthing/questions.yaml
+++ b/charts/stable/syncthing/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/tautulli/questions.yaml
+++ b/charts/stable/tautulli/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/teamspeak3/questions.yaml
+++ b/charts/stable/teamspeak3/questions.yaml
@@ -16,6 +16,7 @@ questions:
             editable: false
             type: boolean
             default: false
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/thelounge/questions.yaml
+++ b/charts/stable/thelounge/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/traefik/questions.yaml
+++ b/charts/stable/traefik/questions.yaml
@@ -24,6 +24,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/transmission/questions.yaml
+++ b/charts/stable/transmission/questions.yaml
@@ -24,6 +24,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/truecommand/questions.yaml
+++ b/charts/stable/truecommand/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/tvheadend/questions.yaml
+++ b/charts/stable/tvheadend/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/unifi/questions.yaml
+++ b/charts/stable/unifi/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/unpackerr/questions.yaml
+++ b/charts/stable/unpackerr/questions.yaml
@@ -1,6 +1,7 @@
 # Include{groups}
 
 questions:
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/vaultwarden/questions.yaml
+++ b/charts/stable/vaultwarden/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/xteve/questions.yaml
+++ b/charts/stable/xteve/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/charts/stable/zwavejs2mqtt/questions.yaml
+++ b/charts/stable/zwavejs2mqtt/questions.yaml
@@ -23,6 +23,7 @@ questions:
             editable: false
             type: boolean
             default: true
+# Include{global}
   - variable: controller
     group: "Controller"
     label: ""

--- a/templates/questions/global.yaml
+++ b/templates/questions/global.yaml
@@ -1,0 +1,19 @@
+  - variable: global
+    label: "global settings"
+    group: "Controller"
+    schema:
+      type: dict
+      hidden: true
+      items:
+        - variable: persistenceListEntry
+          label: "Custom Storage"
+          schema:
+            type: dict
+            hidden: true
+            attrs:
+              - variable: isSCALE
+                label: "flag this is SCALE"
+                schema:
+                  type: boolean
+                  default: true
+                  hidden: true

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -130,6 +130,11 @@ include_questions(){
     local target="catalog/${train}/${chartname}/${chartversion}"
     echo "Including standardised questions.yaml includes for: ${chartname}"
 
+    # Replace # Include{global} with the standard global codesnippet
+    awk 'NR==FNR { a[n++]=$0; next }
+    /# Include{global}/ { for (i=0;i<n;++i) print a[i]; next }
+    1' templates/questions/global.yaml ${target}/questions.yaml > tmp && mv tmp ${target}/questions.yaml
+
     # Replace # Include{groups} with the standard groups codesnippet
     awk 'NR==FNR { a[n++]=$0; next }
     /# Include{groups}/ { for (i=0;i<n;++i) print a[i]; next }


### PR DESCRIPTION
**Description**
Currently database is broken, this should provide the backend code needed to ensure the default storageClass on SCALE is rendered correctly without manual setting it.

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
