### PR TITLE
fix(common): set default ndots to 1 and fix dnsoptions in GUI

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.3.16
+version: 8.3.17

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -256,7 +256,9 @@ dnsPolicy:  # ClusterFirst
 
 # -- Optional DNS settings, configuring the ndots option may resolve nslookup issues on some Kubernetes setups.
 dnsConfig:
-  options: []
+  options:
+    - name: ndots
+      value: "1"
   nameservers: []
   searches: []
 

--- a/templates/questions/serviceExpert.yaml
+++ b/templates/questions/serviceExpert.yaml
@@ -40,7 +40,16 @@
                     - variable: option
                       label: "Option Entry"
                       schema:
-                        type: string
+                        type: dict
+                        attrs:
+                          - variable: name
+                            label: "Name"
+                            schema:
+                              type: string
+                          - variable: value
+                            label: "Value"
+                            schema:
+                              type: string
               - variable: searches
                 label: "Searches"
                 schema:


### PR DESCRIPTION
**Description**
There are some edge cases (when search domain is set) that kubeDNS freaks out (breaks) with the default ndots:5.
As we already advice to use FQDN for cross-namespace App linking, we should be pretty-much in the clear using ndots:1

This PR also fixes the GUI for dns options, which happened to be broken.

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
