### PR TITLE
feat(common): introduce simplePVC and simplyHP aliasses for persistence types

### DIFF
--- a/charts/library/common-test/ci/simple-persistence-values.yaml
+++ b/charts/library/common-test/ci/simple-persistence-values.yaml
@@ -1,0 +1,107 @@
+image:
+  repository: traefik/whoami
+  pullPolicy: IfNotPresent
+  tag: v1.6.1@sha256:2c52bb2c848038a33e40415c300b655d7976bafaf033ecf4a6679cb9e1715917
+
+service:
+  main:
+    ports:
+      main:
+        port: 8080
+
+args:
+  - --port
+  - '8080'
+
+ingress:
+  main:
+    enabled: true
+
+probes:
+  liveness:
+    enabled: true
+  readiness:
+    enabled: true
+  startup:
+    enabled: true
+
+
+persistence:
+  simple-pvc:
+    enabled: true
+    annotationsList: []
+    annotations: {}
+    labelsList: []
+    labels: {}
+    type: simplePVC
+    forceName: ""
+    mountPath:
+    readOnly: false
+    nameOverride:
+    storageClass:
+    existingClaim:
+    subPath:
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    retain: false
+  simple-hostpath:
+    enabled: true
+    type: simpleHP
+    hostPath: /usr
+    mountPath:
+    hostPathType: ""
+    readOnly: false
+
+"ixCertificateAuthorities": {}
+"ixCertificates":
+  "1":
+    "CA_type_existing": false
+    "CA_type_intermediate": false
+    "CA_type_internal": false
+    "CSR": ""
+    "DN": "/C=US/O=iXsystems/CN=localhost/emailAddress=info@ixsystems.com/ST=Tennessee/L=Maryville/subjectAltName=DNS:localhost"
+    "cert_type": "CERTIFICATE"
+    "cert_type_CSR": false
+    "cert_type_existing": true
+    "cert_type_internal": false
+    "certificate": "-----BEGIN CERTIFICATE-----\nMIIDqjCCApKgAwIBAgIBATANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMx\nEjAQBgNVBAoMCWlYc3lzdGVtczESMBAGA1UEAwwJbG9jYWxob3N0MSEwHwYJKoZI\nhvcNAQkBFhJpbmZvQGl4c3lzdGVtcy5jb20xEjAQBgNVBAgMCVRlbm5lc3NlZTES\nMBAGA1UEBwwJTWFyeXZpbGxlMB4XDTIwMDkyNTE0MDUzOFoXDTIyMTIyOTE0MDUz\nOFowgYAxCzAJBgNVBAYTAlVTMRIwEAYDVQQKDAlpWHN5c3RlbXMxEjAQBgNVBAMM\nCWxvY2FsaG9zdDEhMB8GCSqGSIb3DQEJARYSaW5mb0BpeHN5c3RlbXMuY29tMRIw\nEAYDVQQIDAlUZW5uZXNzZWUxEjAQBgNVBAcMCU1hcnl2aWxsZTCCASIwDQYJKoZI\nhvcNAQEBBQADggEPADCCAQoCggEBALpoGliii6X8DeoFdLcR7jjsfJIn3nC8f1pT\nLQ3RURHUOEyhPT3Z6TkhaHeHoj8D6kiXROhyJJq3kw5OeqGZisfpGQhkxjpxkfh9\nfAhlvhuLwCWHaMvSh1TaT+h9+eHfcx3un5CIaH8b1KYRBMH+jmKFpr7jkPNkBXLS\nMA7jKIIa8pD9R6lF4gAsbqJafCbT3R7bqkd9xp3n3j2YhqQzETU2lmu4fra3BPio\nofK47kSkguUC6mtk6VrDf2+QtCKlY0dtbF3e2ZBNWo1aj86sjCtoEmqOCMsPRLc/\nXwQcfEqHY4XfafXwqk0G0UxV2ce18xKoR/pN3MpLBZ65NzPnpn0CAwEAAaMtMCsw\nFAYDVR0RBA0wC4IJbG9jYWxob3N0MBMGA1UdJQQMMAoGCCsGAQUFBwMBMA0GCSqG\nSIb3DQEBCwUAA4IBAQBFW1R037y7wllg/gRk9p2T1stiG8iIXosblmL4Ak1YToTQ\n/0to5GY2ZYW29+rbA4SDTS5eeu2YqZ0A/fF3wey7ggzMS7KyNBOvx5QBJRw3PJGn\n+THfhXvdfkOyeUC6KWRGLgl+/zBFvgh6vFDq3jmv0NI4ehVBTBMCJn7r6577S16T\nwtgKMCooizII0Odu5HIF10gTieFIH3PQYm9JBji9iyemb9Ht3wn7fXQptfGadz/l\nWz/Dv9+a6IOr7JVJMHnqAIvPzpkav4efuVPOX1zbhjg4K5g+nRYfjr5F5upOd0Y3\nznWTUBUyI7CXRkpHtSDXfEqKgnk/8uv7GWw+hyKr\n-----END CERTIFICATE-----\n"
+    "certificate_path": "/etc/certificates/freenas_default.crt"
+    "chain": false
+    "chain_list": [
+      "-----BEGIN CERTIFICATE-----\nMIIDqjCCApKgAwIBAgIBATANBgkqhkiG9w0BAQsFADCBgDELMAkGA1UEBhMCVVMx\nEjAQBgNVBAoMCWlYc3lzdGVtczESMBAGA1UEAwwJbG9jYWxob3N0MSEwHwYJKoZI\nhvcNAQkBFhJpbmZvQGl4c3lzdGVtcy5jb20xEjAQBgNVBAgMCVRlbm5lc3NlZTES\nMBAGA1UEBwwJTWFyeXZpbGxlMB4XDTIwMDkyNTE0MDUzOFoXDTIyMTIyOTE0MDUz\nOFowgYAxCzAJBgNVBAYTAlVTMRIwEAYDVQQKDAlpWHN5c3RlbXMxEjAQBgNVBAMM\nCWxvY2FsaG9zdDEhMB8GCSqGSIb3DQEJARYSaW5mb0BpeHN5c3RlbXMuY29tMRIw\nEAYDVQQIDAlUZW5uZXNzZWUxEjAQBgNVBAcMCU1hcnl2aWxsZTCCASIwDQYJKoZI\nhvcNAQEBBQADggEPADCCAQoCggEBALpoGliii6X8DeoFdLcR7jjsfJIn3nC8f1pT\nLQ3RURHUOEyhPT3Z6TkhaHeHoj8D6kiXROhyJJq3kw5OeqGZisfpGQhkxjpxkfh9\nfAhlvhuLwCWHaMvSh1TaT+h9+eHfcx3un5CIaH8b1KYRBMH+jmKFpr7jkPNkBXLS\nMA7jKIIa8pD9R6lF4gAsbqJafCbT3R7bqkd9xp3n3j2YhqQzETU2lmu4fra3BPio\nofK47kSkguUC6mtk6VrDf2+QtCKlY0dtbF3e2ZBNWo1aj86sjCtoEmqOCMsPRLc/\nXwQcfEqHY4XfafXwqk0G0UxV2ce18xKoR/pN3MpLBZ65NzPnpn0CAwEAAaMtMCsw\nFAYDVR0RBA0wC4IJbG9jYWxob3N0MBMGA1UdJQQMMAoGCCsGAQUFBwMBMA0GCSqG\nSIb3DQEBCwUAA4IBAQBFW1R037y7wllg/gRk9p2T1stiG8iIXosblmL4Ak1YToTQ\n/0to5GY2ZYW29+rbA4SDTS5eeu2YqZ0A/fF3wey7ggzMS7KyNBOvx5QBJRw3PJGn\n+THfhXvdfkOyeUC6KWRGLgl+/zBFvgh6vFDq3jmv0NI4ehVBTBMCJn7r6577S16T\nwtgKMCooizII0Odu5HIF10gTieFIH3PQYm9JBji9iyemb9Ht3wn7fXQptfGadz/l\nWz/Dv9+a6IOr7JVJMHnqAIvPzpkav4efuVPOX1zbhjg4K5g+nRYfjr5F5upOd0Y3\nznWTUBUyI7CXRkpHtSDXfEqKgnk/8uv7GWw+hyKr\n-----END CERTIFICATE-----\n"
+    ]
+    "city": "Maryville"
+    "common": "localhost"
+    "country": "US"
+    "csr_path": "/etc/certificates/freenas_default.csr"
+    "digest_algorithm": "SHA256"
+    "email": "info@ixsystems.com"
+    "extensions":
+      "ExtendedKeyUsage": "TLS Web Server Authentication"
+      "SubjectAltName": "DNS:localhost"
+    "fingerprint": "9C:5A:1D:1B:E7:9E:0B:89:2B:37:F4:19:83:ED:3C:6B:D8:14:0D:9B"
+    "from": "Fri Sep 25 16:05:38 2020"
+    "id": 1
+    "internal": "NO"
+    "issuer": "external"
+    "key_length": 2048
+    "key_type": "RSA"
+    "lifetime": 825
+    "name": "freenas_default"
+    "organization": "iXsystems"
+    "organizational_unit": ""
+    "parsed": true
+    "privatekey": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC6aBpYooul/A3q\nBXS3Ee447HySJ95wvH9aUy0N0VER1DhMoT092ek5IWh3h6I/A+pIl0TociSat5MO\nTnqhmYrH6RkIZMY6cZH4fXwIZb4bi8Alh2jL0odU2k/offnh33Md7p+QiGh/G9Sm\nEQTB/o5ihaa+45DzZAVy0jAO4yiCGvKQ/UepReIALG6iWnwm090e26pHfcad5949\nmIakMxE1NpZruH62twT4qKHyuO5EpILlAuprZOlaw39vkLQipWNHbWxd3tmQTVqN\nWo/OrIwraBJqjgjLD0S3P18EHHxKh2OF32n18KpNBtFMVdnHtfMSqEf6TdzKSwWe\nuTcz56Z9AgMBAAECggEARwcb4uIs7BZbBu0FSCyg5TfXT6m5bKOmszg2VqmHho+i\n1DAsMcEyyP4d3E3mWLSZNQfOzfOQVxPUCQOGXsUuyHXdgAFGN0bHJDRMara59a0O\njj5GhEO4JXD6OdCmwpZuOt2OF3iiuKxWHuElOvZQMuJSYzI7LULTgKjufv23lbsf\nxMO/v9yi57c5EGgnQ8siLKOy/FQZapn4Z9qKn+lVyk5gfaKP0pDsvV4d7nGYMDD2\nYijfkSyNecApFdtWiLE5zLUlvF6oNj8o66z3YrVNKrCPzhA/5Rkkwwk32SNxvKU3\nVZFSNPeOZ60BicxYcWO+b2aAa0WF+uazJAZ4q52gUQKBgQDu88R+0wm76secYkzE\nQglteLNZKFcvth0kI5xH42Hmk9IXkGimFoDJCIrLAuopyGnfNmqmh2is3QUMUPdR\n/wDLnKc4MCezEidNoD2RBC+bzM1hB9oye/b5sOZUDFXSa0k4XSLu1UEuy1yWhkuS\n6JjY1KQfc4FN0K0Fjqqo7UCTCwKBgQDHtKQh/NvMJ2ok4YW+/QAsus4mEK9eCyUy\nOuyDszQYrGvjkS7STKJVNxGLhWb0XKSIAxMZ66b1MwOt+71h7xNn6pcancfVdK7F\n1Xl5J+76SwbXSgQwTZuoMDxPIvZn7v/2ep5Ni/BcOhMcPIcobWb/OmXrFN1brBvo\nlFNQyWWhlwKBgFDAyPMjVvLO0U6kWdUpjA4W8GV9IJnbLdX8wt/4lClcY2/bOcKH\ncFaAMIeTIJemR0FMHpbQxCtHNmGHK03mo9orwsdWXtRBmk69jJDpnT1F5VKZWMAe\n7MRNaEmXMZm+8CvALgIQx8qMp2mnUPsA6Ea+9gg6/MPTdeWe5UXZiC0pAoGAGtSt\nPJfBXBNrklruYjORo3DRo5GYThVHQRFjl2orNKltsVxfIwgCw1ortEgPBgOwY0mu\ndkwP2V+qPeTVk+PQAqUk+gF6yLXtiUzeDiYMWHpeB+y81VSH9jfM0oELA/m7T/03\naYnEmE+BI8kKC6dvMBlDeisKdneQJFZRP0hfrC8CgYEAgYIyCGwcydKpe2Nkj0Fz\nKTtCMC/k4DvJfd5Kb9AbmrPUfKgA9Xj4GT6yPG6uBMi8r5etvLCKJ2x2NtN024a8\nQJLATYPrSsaZkE+9zM0j5nYAgbKpxBhlDzDAzn//3ByVzfgJ25S80XhTI2lfbLH/\nU07ssxdZaQCo+WuD82OvNcg=\n-----END PRIVATE KEY-----\n"
+    "privatekey_path": "/etc/certificates/freenas_default.key"
+    "revoked": false
+    "revoked_date": ""
+    "root_path": "/etc/certificates"
+    "san": [
+      "DNS:localhost"
+    ]
+    "serial": 1
+    "signedby": ""
+    "state": "Tennessee"
+    "subject_name_hash": 3193428416
+    "type": 8
+    "until": "Thu Dec 29 15:05:38 2022"

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.4.0
+version: 8.5.0

--- a/charts/library/common/templates/lib/chart/_values.tpl
+++ b/charts/library/common/templates/lib/chart/_values.tpl
@@ -248,6 +248,7 @@
   {{- end }}
 
   {{- range .Values.persistence }}
+  {{- if .type }}
   {{- if eq .type "simplePVC" }}
   {{- $_ := set . "type" "pvc" }}
   {{- end }}
@@ -255,10 +256,13 @@
   {{- $_ := set . "type" "hostPath" }}
   {{- end }}
   {{- end }}
+  {{- end }}
 
   {{- range .Values.service }}
+  {{- if .type }}
   {{- if eq .type "Simple" }}
   {{- $_ := set . "type" "LoadBalancer" }}
+  {{- end }}
   {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/library/common/templates/lib/chart/_values.tpl
+++ b/charts/library/common/templates/lib/chart/_values.tpl
@@ -90,7 +90,6 @@
    {{- end }}
    {{- end }}
 
-
   {{/* merge ingressList with ingress */}}
   {{- $ingDict := dict }}
   {{- range $index, $item := .Values.ingressList -}}
@@ -246,6 +245,15 @@
   {{- end }}
   {{- if $CapAdd }}
   {{- $_ := set .Values.securityContext.capabilities "add" $CapAdd -}}
+  {{- end }}
+
+  {{- range .Values.persistence }}
+  {{- if eq .type "SimplePVC" }}
+  {{- $_ := set . "type" "pvc" }}
+  {{- end }}
+  {{- if eq .type "SimpleHP" }}
+  {{- $_ := set . "type" "hostPath" }}
+  {{- end }}
   {{- end }}
 
   {{- range .Values.service }}

--- a/charts/library/common/templates/lib/chart/_values.tpl
+++ b/charts/library/common/templates/lib/chart/_values.tpl
@@ -248,10 +248,10 @@
   {{- end }}
 
   {{- range .Values.persistence }}
-  {{- if eq .type "SimplePVC" }}
+  {{- if eq .type "simplePVC" }}
   {{- $_ := set . "type" "pvc" }}
   {{- end }}
-  {{- if eq .type "SimpleHP" }}
+  {{- if eq .type "simpleHP" }}
   {{- $_ := set . "type" "hostPath" }}
   {{- end }}
   {{- end }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -565,7 +565,7 @@ persistence:
     labels: {}
 
     # -- Sets the persistence type
-    # Valid options are pvc, emptyDir, hostPath or custom
+    # Valid options are: simplePVC, simpleHP, pvc, emptyDir, hostPath or custom
     type: pvc
 
     # -- force the complete PVC name
@@ -602,7 +602,7 @@ persistence:
     accessMode: ReadWriteOnce
 
     # -- The amount of storage that is requested for the persistent volume.
-    size: 1Gi
+    size: 999Gi
 
     # - Set to true to retain the PVC upon `helm uninstall`
     retain: false

--- a/templates/questions/persistenceList.yaml
+++ b/templates/questions/persistenceList.yaml
@@ -16,6 +16,110 @@
                   type: boolean
                   default: true
                   hidden: true
+              - variable: type
+                label: "Type of Storage"
+                description: "Sets the persistence type, Anything other than PVC could break rollback!""
+                schema:
+                  type: string
+                  default: "simpleHP"
+                  enum:
+                    - value: "simplePVC"
+                      description: "PVC (simple)"
+                    - value: "simpleHP"
+                      description: "HostPath (simple)"
+                    - value: "emptyDir"
+                      description: "emptyDir"
+                    - value: "pvc"
+                      description: "pvc"
+                    - value: "hostPath"
+                      description: "hostPath"
+              - variable: setPermissions
+                label: "Automatic Permissions"
+                description: "Automatically set permissions on install"
+                schema:
+                  show_if: [["type", "=", "hostPath"],["type", "=", simpleHP]]
+                  type: boolean
+                  default: true
+              - variable: readOnly
+                label: "readOnly"
+                schema:
+                  type: boolean
+                  default: false
+              - variable: hostPath
+                label: "hostPath"
+                description: "Path inside the container the storage is mounted"
+                schema:
+                  show_if: [["type", "=", "hostPath"],["type", "=", simpleHP]]
+                  type: hostpath
+              - variable: mountPath
+                label: "mountPath"
+                description: "Path inside the container the storage is mounted"
+                schema:
+                  type: string
+                  default: ""
+                  required: true
+                  valid_chars: '^\/([a-zA-Z0-9._-]+\/?)+$'
+              - variable: medium
+                label: "EmptyDir Medium"
+                schema:
+                  show_if: [["type", "=", "emptyDir"]]
+                  type: string
+                  default: ""
+                  enum:
+                    - value: ""
+                      description: "Default"
+                    - value: "Memory"
+                      description: "Memory"
+              - variable: size
+                label: "Size quotum of storage"
+                schema:
+                  show_if: [["type", "=", "pvc"],["type", "=", simplePVC]]
+                  type: string
+                  default: "100Gi"
+              - variable: hostPathType
+                label: "(Advanced) hostPath Type"
+                schema:
+                  show_if: [["type", "=", "hostPath"]]
+                  type: string
+                  default: ""
+                  enum:
+                    - value: ""
+                      description: "Default"
+                    - value: "DirectoryOrCreate"
+                      description: "DirectoryOrCreate"
+                    - value: "Directory"
+                      description: "Directory"
+                    - value: "FileOrCreate"
+                      description: "FileOrCreate"
+                    - value: "File"
+                      description: "File"
+                    - value: "Socket"
+                      description: "Socket"
+                    - value: "CharDevice"
+                      description: "CharDevice"
+                    - value: "BlockDevice"
+                      description: "BlockDevice"
+              - variable: storageClass
+                label: "(Advanced) storageClass"
+                description: "Warning: Anything other than SCALE-ZFS or empty will break rollback!"
+                schema:
+                  show_if: [["type", "=", "pvc"]]
+                  type: string
+                  default: "SCALE-ZFS"
+              - variable: accessMode
+                label: "(Advanced) Access Mode"
+                description: "Allow or disallow multiple PVC's writhing to the same PV"
+                schema:
+                  show_if: [["type", "=", "pvc"]]
+                  type: string
+                  default: "ReadWriteOnce"
+                  enum:
+                    - value: "ReadWriteOnce"
+                      description: "ReadWriteOnce"
+                    - value: "ReadOnlyMany"
+                      description: "ReadOnlyMany"
+                    - value: "ReadWriteMany"
+                      description: "ReadWriteMany"
               - variable: advanced
                 label: "Show Advanced Options"
                 schema:
@@ -61,103 +165,3 @@
                                   label: "Value"
                                   schema:
                                     type: string
-              - variable: type
-                label: "(Advanced) Type of Storage"
-                description: "Sets the persistence type"
-                schema:
-                  type: string
-                  default: "hostPath"
-                  enum:
-                    - value: "pvc"
-                      description: "pvc"
-                    - value: "emptyDir"
-                      description: "emptyDir"
-                    - value: "hostPath"
-                      description: "hostPath"
-              - variable: storageClass
-                label: "(Advanced) storageClass"
-                description: "Warning: Anything other than SCALE-ZFS will break rollback!"
-                schema:
-                  show_if: [["type", "=", "pvc"]]
-                  type: string
-                  default: "SCALE-ZFS"
-              - variable: setPermissions
-                label: "Automatic Permissions"
-                description: "Automatically set permissions on install"
-                schema:
-                  show_if: [["type", "=", "hostPath"]]
-                  type: boolean
-                  default: true
-              - variable: readOnly
-                label: "readOnly"
-                schema:
-                  type: boolean
-                  default: false
-              - variable: hostPath
-                label: "hostPath"
-                description: "Path inside the container the storage is mounted"
-                schema:
-                  show_if: [["type", "=", "hostPath"]]
-                  type: hostpath
-              - variable: hostPathType
-                label: "(Advanced) hostPath Type"
-                schema:
-                  show_if: [["type", "=", "hostPath"]]
-                  type: string
-                  default: ""
-                  enum:
-                    - value: ""
-                      description: "Default"
-                    - value: "DirectoryOrCreate"
-                      description: "DirectoryOrCreate"
-                    - value: "Directory"
-                      description: "Directory"
-                    - value: "FileOrCreate"
-                      description: "FileOrCreate"
-                    - value: "File"
-                      description: "File"
-                    - value: "Socket"
-                      description: "Socket"
-                    - value: "CharDevice"
-                      description: "CharDevice"
-                    - value: "BlockDevice"
-                      description: "BlockDevice"
-              - variable: mountPath
-                label: "mountPath"
-                description: "Path inside the container the storage is mounted"
-                schema:
-                  type: string
-                  default: ""
-                  required: true
-                  valid_chars: '^\/([a-zA-Z0-9._-]+\/?)+$'
-              - variable: medium
-                label: "EmptyDir Medium"
-                schema:
-                  show_if: [["type", "=", "emptyDir"]]
-                  type: string
-                  default: ""
-                  enum:
-                    - value: ""
-                      description: "Default"
-                    - value: "Memory"
-                      description: "Memory"
-              - variable: accessMode
-                label: "(Advanced) Access Mode"
-                description: "Allow or disallow multiple PVC's writhing to the same PV"
-                schema:
-                  show_if: [["type", "=", "pvc"]]
-                  type: string
-                  default: "ReadWriteOnce"
-                  enum:
-                    - value: "ReadWriteOnce"
-                      description: "ReadWriteOnce"
-                    - value: "ReadOnlyMany"
-                      description: "ReadOnlyMany"
-                    - value: "ReadWriteMany"
-                      description: "ReadWriteMany"
-              - variable: size
-                label: "Size quotum of storage"
-                schema:
-                  show_if: [["type", "=", "pvc"]]
-                  type: string
-                  default: "100Gi"


### PR DESCRIPTION
**Description**
By adding 2 alias persistence types for PVC and hostPath we can more easily add additional "simplified" storage config options for new users. This should provide for a beter experience.

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
