### PR TITLE
fix(common): correctly set defaults for volumeclaimtemplates and pvc's

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.6.0
+version: 8.6.1

--- a/charts/library/common/templates/_statefulset.tpl
+++ b/charts/library/common/templates/_statefulset.tpl
@@ -65,7 +65,7 @@ spec:
             storage: {{ $values.size | default "999Gi" | quote }}
         {{- if $vct.storageClass }}
         storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else if (eq "SCALE-ZFS" $vct.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" $releaseName ) }}{{- else }}{{ $vct.storageClass | quote }}{{- end }}
-        {{- else if or ( $.Values.global.isSCALE ) ( $values.ixChartContext ) ( $values.global.ixChartContext ) }}
+        {{- else if or ( hasKey $values.global "isSCALE" ) ( hasKey  $values "ixChartContext" ) ( hasKey $values.global "ixChartContext" ) }}
         storageClassName: {{ printf "%v-%v"  "ix-storage-class" $releaseName }}
         {{- end }}
     {{- end }}

--- a/charts/library/common/templates/_statefulset.tpl
+++ b/charts/library/common/templates/_statefulset.tpl
@@ -65,7 +65,7 @@ spec:
             storage: {{ $values.size | default "999Gi" | quote }}
         {{- if $vct.storageClass }}
         storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else if (eq "SCALE-ZFS" $vct.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" $releaseName ) }}{{- else }}{{ $vct.storageClass | quote }}{{- end }}
-        {{- else if or ( $values.global.isSCALE ) ( hasKey $values.global "ixChartContext" ) }}
+        {{- else if or ( $values.global.isSCALE ) ( $values.global.ixChartContext ) }}
         storageClassName: {{ printf "%v-%v"  "ix-storage-class" $releaseName }}
         {{- end }}
     {{- end }}

--- a/charts/library/common/templates/_statefulset.tpl
+++ b/charts/library/common/templates/_statefulset.tpl
@@ -65,7 +65,7 @@ spec:
             storage: {{ $values.size | default "999Gi" | quote }}
         {{- if $vct.storageClass }}
         storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else if (eq "SCALE-ZFS" $vct.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" $releaseName ) }}{{- else }}{{ $vct.storageClass | quote }}{{- end }}
-        {{- else if or ( $values.global.isSCALE ) ( $values.global.ixChartContext ) }}
+        {{- else if or ( $values.global.isSCALE ) ( $values.ixChartContext ) ( $values.global.ixChartContext ) }}
         storageClassName: {{ printf "%v-%v"  "ix-storage-class" $releaseName }}
         {{- end }}
     {{- end }}

--- a/charts/library/common/templates/_statefulset.tpl
+++ b/charts/library/common/templates/_statefulset.tpl
@@ -65,7 +65,7 @@ spec:
             storage: {{ $values.size | default "999Gi" | quote }}
         {{- if $vct.storageClass }}
         storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else if (eq "SCALE-ZFS" $vct.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" $releaseName ) }}{{- else }}{{ $vct.storageClass | quote }}{{- end }}
-        {{- else if or ( $values.global.isSCALE ) ( $values.global.ixChartContext ) }}
+        {{- else if or ( $values.global.isSCALE ) ( hasKey $values.global "ixChartContext" ) }}
         storageClassName: {{ printf "%v-%v"  "ix-storage-class" $releaseName }}
         {{- end }}
     {{- end }}

--- a/charts/library/common/templates/_statefulset.tpl
+++ b/charts/library/common/templates/_statefulset.tpl
@@ -59,13 +59,13 @@ spec:
         name: {{ $vctname }}
       spec:
         accessModes:
-          - {{ required (printf "accessMode is required for vCT %v" $vct.name) $vct.accessMode  | quote }}
+          - {{ ( $values.accessMode | default "ReadWriteOnce" ) | quote }}
         resources:
           requests:
-            storage: {{ required (printf "size is required for PVC %v" $vct.name) $vct.size | quote }}
+            storage: {{ $values.size | default "999Gi" | quote }}
         {{- if $vct.storageClass }}
         storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else if (eq "SCALE-ZFS" $vct.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" $releaseName ) }}{{- else }}{{ $vct.storageClass | quote }}{{- end }}
-        {{- else if $values.ixChartContext }}
+        {{- else if or ( $.Values.global.isSCALE ) ( $values.ixChartContext ) ( $values.global.ixChartContext ) }}
         storageClassName: {{ printf "%v-%v"  "ix-storage-class" $releaseName }}
         {{- end }}
     {{- end }}

--- a/charts/library/common/templates/_statefulset.tpl
+++ b/charts/library/common/templates/_statefulset.tpl
@@ -65,7 +65,7 @@ spec:
             storage: {{ $values.size | default "999Gi" | quote }}
         {{- if $vct.storageClass }}
         storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else if (eq "SCALE-ZFS" $vct.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" $releaseName ) }}{{- else }}{{ $vct.storageClass | quote }}{{- end }}
-        {{- else if or ( $values.global.isSCALE ) ( hasKey  $values "ixChartContext" ) ( hasKey $values.global "ixChartContext" ) }}
+        {{- else if or ( $values.global.isSCALE ) ( $values.ixChartContext ) ( $values.global.ixChartContext ) }}
         storageClassName: {{ printf "%v-%v"  "ix-storage-class" $releaseName }}
         {{- end }}
     {{- end }}

--- a/charts/library/common/templates/_statefulset.tpl
+++ b/charts/library/common/templates/_statefulset.tpl
@@ -65,7 +65,7 @@ spec:
             storage: {{ $values.size | default "999Gi" | quote }}
         {{- if $vct.storageClass }}
         storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else if (eq "SCALE-ZFS" $vct.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" $releaseName ) }}{{- else }}{{ $vct.storageClass | quote }}{{- end }}
-        {{- else if or ( hasKey $values.global "isSCALE" ) ( hasKey  $values "ixChartContext" ) ( hasKey $values.global "ixChartContext" ) }}
+        {{- else if or ( $values.global.isSCALE ) ( hasKey  $values "ixChartContext" ) ( hasKey $values.global "ixChartContext" ) }}
         storageClassName: {{ printf "%v-%v"  "ix-storage-class" $releaseName }}
         {{- end }}
     {{- end }}

--- a/charts/library/common/templates/_statefulset.tpl
+++ b/charts/library/common/templates/_statefulset.tpl
@@ -65,7 +65,7 @@ spec:
             storage: {{ $values.size | default "999Gi" | quote }}
         {{- if $vct.storageClass }}
         storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else if (eq "SCALE-ZFS" $vct.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" $releaseName ) }}{{- else }}{{ $vct.storageClass | quote }}{{- end }}
-        {{- else if or ( $values.global.isSCALE ) ( $values.ixChartContext ) ( $values.global.ixChartContext ) }}
+        {{- else if or ( $values.global.isSCALE ) ( $values.global.ixChartContext ) }}
         storageClassName: {{ printf "%v-%v"  "ix-storage-class" $releaseName }}
         {{- end }}
     {{- end }}

--- a/charts/library/common/templates/_statefulset.tpl
+++ b/charts/library/common/templates/_statefulset.tpl
@@ -59,10 +59,10 @@ spec:
         name: {{ $vctname }}
       spec:
         accessModes:
-          - {{ ( $values.accessMode | default "ReadWriteOnce" ) | quote }}
+          - {{ ( $vct.accessMode | default "ReadWriteOnce" ) | quote }}
         resources:
           requests:
-            storage: {{ $values.size | default "999Gi" | quote }}
+            storage: {{ $vct.size | default "999Gi" | quote }}
         {{- if $vct.storageClass }}
         storageClassName: {{ if (eq "-" $vct.storageClass) }}""{{- else if (eq "SCALE-ZFS" $vct.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" $releaseName ) }}{{- else }}{{ $vct.storageClass | quote }}{{- end }}
         {{- else if or ( $values.global.isSCALE ) ( $values.ixChartContext ) ( $values.global.ixChartContext ) }}

--- a/charts/library/common/templates/classes/_pvc.tpl
+++ b/charts/library/common/templates/classes/_pvc.tpl
@@ -45,7 +45,7 @@ spec:
       storage: {{ $values.size | default "999Gi" | quote }}
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
-  {{- else if or ( $.Values.global.isSCALE ) ( $.values.ixChartContext ) ( hasKey $.values.global.ixChartContext ) }}
+  {{- else if or ( $.Values.global.isSCALE ) ( hasKey $.values.global.ixChartContext ) }}
   storageClassName: {{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}
   {{- end }}
   {{- if $values.volumeName }}

--- a/charts/library/common/templates/classes/_pvc.tpl
+++ b/charts/library/common/templates/classes/_pvc.tpl
@@ -45,7 +45,7 @@ spec:
       storage: {{ $values.size | default "999Gi" | quote }}
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
-  {{- else if or ( hasKey  $.Values.global "isSCALE" ) ( hasKey  $.values "ixChartContext" ) ( hasKey $.values.global "ixChartContext" ) }}
+  {{- else if or ( $.Values.global.isSCALE ) ( hasKey  $.values "ixChartContext" ) ( hasKey $.values.global "ixChartContext" ) }}
   storageClassName: {{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}
   {{- end }}
   {{- if $values.volumeName }}

--- a/charts/library/common/templates/classes/_pvc.tpl
+++ b/charts/library/common/templates/classes/_pvc.tpl
@@ -45,7 +45,7 @@ spec:
       storage: {{ $values.size | default "999Gi" | quote }}
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
-  {{- else if or ( $.Values.global.isSCALE ) ( $.values.global.ixChartContext ) }}
+  {{- else if or ( $.Values.global.isSCALE ) ( hasKey $.values.global "ixChartContext" ) }}
   storageClassName: {{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}
   {{- end }}
   {{- if $values.volumeName }}

--- a/charts/library/common/templates/classes/_pvc.tpl
+++ b/charts/library/common/templates/classes/_pvc.tpl
@@ -45,7 +45,7 @@ spec:
       storage: {{ $values.size | default "999Gi" | quote }}
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
-  {{- else if or ( $.Values.global.isSCALE ) ( hasKey  $.values "ixChartContext" ) ( hasKey $.values.global "ixChartContext" ) }}
+  {{- else if or ( $.Values.global.isSCALE ) ( $.values.ixChartContext" ) ( hasKey $.values.global.ixChartContext ) }}
   storageClassName: {{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}
   {{- end }}
   {{- if $values.volumeName }}

--- a/charts/library/common/templates/classes/_pvc.tpl
+++ b/charts/library/common/templates/classes/_pvc.tpl
@@ -45,7 +45,7 @@ spec:
       storage: {{ $values.size | default "999Gi" | quote }}
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
-  {{- else if $.Values.global.isSCALE }}
+  {{- else if or ( $.Values.global.isSCALE ) ( $values.ixChartContext ) ( $values.global.ixChartContext ) }}
   storageClassName: {{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}
   {{- end }}
   {{- if $values.volumeName }}

--- a/charts/library/common/templates/classes/_pvc.tpl
+++ b/charts/library/common/templates/classes/_pvc.tpl
@@ -45,7 +45,7 @@ spec:
       storage: {{ $values.size | default "999Gi" | quote }}
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
-  {{- else if or ( $.Values.global.isSCALE ) ( $.values.ixChartContext" ) ( hasKey $.values.global.ixChartContext ) }}
+  {{- else if or ( $.Values.global.isSCALE ) ( $.values.ixChartContext ) ( hasKey $.values.global.ixChartContext ) }}
   storageClassName: {{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}
   {{- end }}
   {{- if $values.volumeName }}

--- a/charts/library/common/templates/classes/_pvc.tpl
+++ b/charts/library/common/templates/classes/_pvc.tpl
@@ -45,7 +45,7 @@ spec:
       storage: {{ $values.size | default "999Gi" | quote }}
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
-  {{- else if or ( $.Values.global.isSCALE ) ( $.values.global.ixChartContext ) }}
+  {{- else if or ( $.Values.global.isSCALE ) ( $.Values.ixChartContext ) ( $.Values.global.ixChartContext ) }}
   storageClassName: {{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}
   {{- end }}
   {{- if $values.volumeName }}

--- a/charts/library/common/templates/classes/_pvc.tpl
+++ b/charts/library/common/templates/classes/_pvc.tpl
@@ -45,7 +45,7 @@ spec:
       storage: {{ $values.size | default "999Gi" | quote }}
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
-  {{- else if or ( $.Values.global.isSCALE ) ( hasKey $.values.global "ixChartContext" ) }}
+  {{- else if or ( $.Values.global.isSCALE ) ( $.values.global.ixChartContext ) }}
   storageClassName: {{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}
   {{- end }}
   {{- if $values.volumeName }}

--- a/charts/library/common/templates/classes/_pvc.tpl
+++ b/charts/library/common/templates/classes/_pvc.tpl
@@ -45,7 +45,7 @@ spec:
       storage: {{ $values.size | default "999Gi" | quote }}
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
-  {{- else if or ( $.Values.global.isSCALE ) ( hasKey $.values.global.ixChartContext ) }}
+  {{- else if or ( $.Values.global.isSCALE ) ( $.values.global.ixChartContext ) }}
   storageClassName: {{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}
   {{- end }}
   {{- if $values.volumeName }}

--- a/charts/library/common/templates/classes/_pvc.tpl
+++ b/charts/library/common/templates/classes/_pvc.tpl
@@ -45,7 +45,7 @@ spec:
       storage: {{ $values.size | default "999Gi" | quote }}
   {{- if $values.storageClass }}
   storageClassName: {{ if (eq "-" $values.storageClass) }}""{{- else if (eq "SCALE-ZFS" $values.storageClass ) }}{{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}{{- else }}{{ $values.storageClass | quote }}{{- end }}
-  {{- else if or ( $.Values.global.isSCALE ) ( $values.ixChartContext ) ( $values.global.ixChartContext ) }}
+  {{- else if or ( hasKey  $.Values.global "isSCALE" ) ( hasKey  $.values "ixChartContext" ) ( hasKey $.values.global "ixChartContext" ) }}
   storageClassName: {{ ( printf "%v-%v"  "ix-storage-class" .Release.Name ) }}
   {{- end }}
   {{- if $values.volumeName }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -75,6 +75,7 @@ global:
   # -- Set the entire name definition
   fullnameOverride:
   isSCALE: false
+  ixChartContext: {}
 
 controller:
   # -- enable the controller.

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -75,7 +75,6 @@ global:
   # -- Set the entire name definition
   fullnameOverride:
   isSCALE: false
-  ixChartContext: {}
 
 controller:
   # -- enable the controller.


### PR DESCRIPTION
**Description**
This fixes two issues:
- We prepare some code for nightly/rc2 to check if an install uses SCALE based storageclasses on PVC and VCT
- We add default modes to VCT
- We add default size to VCT

**Type of change**

- [X] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
