### PR TITLE
feat(deps): move postgresql to use statefullset and cleanup

### DIFF
--- a/charts/dependency/mariadb/Chart.yaml
+++ b/charts/dependency/mariadb/Chart.yaml
@@ -24,7 +24,7 @@ sources:
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
 type: application
-version: 1.0.0
+version: 1.0.1
 annotations:
   truecharts.org/catagories: |
     - database

--- a/charts/dependency/mariadb/questions.yaml
+++ b/charts/dependency/mariadb/questions.yaml
@@ -34,7 +34,7 @@ questions:
                 label: "(Advanced) Controller Type"
                 schema:
                   type: string
-                  default: "deployment"
+                  default: "statefulset"
                   required: true
                   enum:
                     - value: "deployment"
@@ -178,15 +178,15 @@ questions:
 
 # Include{serviceList}
 
-  - variable: persistence
+  - variable: volumeClaimTemplates
     label: "Integrated Persistent Storage"
     description: "Integrated Persistent Storage"
     group: "Storage and Persistence"
     schema:
       type: dict
       attrs:
-        - variable: db
-          label: "Old db Storage"
+        - variable: data
+          label: "DB Storage"
           description: "Stores the old Application Database."
           schema:
             type: dict

--- a/charts/dependency/mariadb/questions.yaml
+++ b/charts/dependency/mariadb/questions.yaml
@@ -207,14 +207,8 @@ questions:
                   enum:
                     - value: "simplePVC"
                       description: "PVC (simple)"
-                    - value: "simpleHP"
-                      description: "HostPath (simple)"
-                    - value: "emptyDir"
-                      description: "emptyDir"
                     - value: "pvc"
                       description: "pvc"
-                    - value: "hostPath"
-                      description: "hostPath"
 # Include{persistenceBasic}
               - variable: hostPath
                 label: "hostPath"

--- a/charts/dependency/mariadb/questions.yaml
+++ b/charts/dependency/mariadb/questions.yaml
@@ -55,7 +55,7 @@ questions:
                 label: "(Advanced) Update Strategy"
                 schema:
                   type: string
-                  default: "Recreate"
+                  default: "RollingUpdate"
                   required: true
                   enum:
                     - value: "Recreate"

--- a/charts/dependency/mariadb/values.yaml
+++ b/charts/dependency/mariadb/values.yaml
@@ -40,10 +40,9 @@ podSecurityContext:
   runAsGroup: 0
 
 volumeClaimTemplates:
-  db:
+  data:
     enabled: true
     mountPath: "/bitnami/mariadb"
-    accessMode: ReadWriteOnce
 
 # -- Probe configuration
 # -- [[ref]](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)

--- a/charts/dependency/postgresql/Chart.yaml
+++ b/charts/dependency/postgresql/Chart.yaml
@@ -22,7 +22,7 @@ name: postgresql
 sources:
 - https://www.postgresql.org/
 type: application
-version: 5.1.18
+version: 5.2.0
 annotations:
   truecharts.org/catagories: |
     - database

--- a/charts/dependency/postgresql/questions.yaml
+++ b/charts/dependency/postgresql/questions.yaml
@@ -186,7 +186,7 @@ questions:
       type: dict
       attrs:
         - variable: data
-          label: "Old db Storage"
+          label: "DB Storage"
           description: "Stores the old Application Database."
           schema:
             type: dict

--- a/charts/dependency/postgresql/questions.yaml
+++ b/charts/dependency/postgresql/questions.yaml
@@ -207,14 +207,8 @@ questions:
                   enum:
                     - value: "simplePVC"
                       description: "PVC (simple)"
-                    - value: "simpleHP"
-                      description: "HostPath (simple)"
-                    - value: "emptyDir"
-                      description: "emptyDir"
                     - value: "pvc"
                       description: "pvc"
-                    - value: "hostPath"
-                      description: "hostPath"
 # Include{persistenceBasic}
               - variable: hostPath
                 label: "hostPath"

--- a/charts/dependency/postgresql/questions.yaml
+++ b/charts/dependency/postgresql/questions.yaml
@@ -34,7 +34,7 @@ questions:
                 label: "(Advanced) Controller Type"
                 schema:
                   type: string
-                  default: "Statefulset"
+                  default: "statefulset"
                   required: true
                   enum:
                     - value: "deployment"

--- a/charts/dependency/postgresql/questions.yaml
+++ b/charts/dependency/postgresql/questions.yaml
@@ -34,7 +34,7 @@ questions:
                 label: "(Advanced) Controller Type"
                 schema:
                   type: string
-                  default: "deployment"
+                  default: "Statefulset"
                   required: true
                   enum:
                     - value: "deployment"
@@ -178,14 +178,14 @@ questions:
 
 # Include{serviceList}
 
-  - variable: persistence
+  - variable: volumeClaimTemplates
     label: "Integrated Persistent Storage"
     description: "Integrated Persistent Storage"
     group: "Storage and Persistence"
     schema:
       type: dict
       attrs:
-        - variable: db
+        - variable: data
           label: "Old db Storage"
           description: "Stores the old Application Database."
           schema:

--- a/charts/dependency/postgresql/questions.yaml
+++ b/charts/dependency/postgresql/questions.yaml
@@ -55,7 +55,7 @@ questions:
                 label: "(Advanced) Update Strategy"
                 schema:
                   type: string
-                  default: "Recreate"
+                  default: "RollingUpdate"
                   required: true
                   enum:
                     - value: "Recreate"

--- a/charts/dependency/postgresql/values.yaml
+++ b/charts/dependency/postgresql/values.yaml
@@ -37,9 +37,9 @@ initContainers:
       - |
         echo 'trying to migrate old db to new location...'
         mkdir -p /bitnami/postgresql/data
-        mv -f /bitnami/postgresql/old/* /bitnami/postgresql/data/ || true
-        chown -R {{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }} /bitnami/postgresql/data
-        chmod 775 /bitnami/postgresql/data
+        mv -f /bitnami/postgresql/old/* /bitnami/postgresql/ || true
+        chown -R {{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }} /bitnami/postgresql/
+        chmod 775 /bitnami/postgresql/
     imagePullPolicy: IfNotPresent
     volumeMounts:
       - name: db

--- a/charts/dependency/postgresql/values.yaml
+++ b/charts/dependency/postgresql/values.yaml
@@ -3,6 +3,50 @@ image:
   pullPolicy: IfNotPresent
   tag: 14.1.0@sha256:480fa9cd68d9013ea622b8a6dc71505bc8f0eaeac6d062cb5182bff44d0fcdbb
 
+controller:
+  # -- Set the controller type.
+  # Valid options are deployment, daemonset or statefulset
+  type: statefulset
+  # -- Number of desired pods
+  replicas: 1
+  # -- Set the controller upgrade strategy
+  # For Deployments, valid values are Recreate (default) and RollingUpdate.
+  # For StatefulSets, valid values are OnDelete and RollingUpdate (default).
+  # DaemonSets ignore this.
+  strategy: Recreate
+  rollingUpdate:
+    # -- Set deployment RollingUpdate max unavailable
+    unavailable: 1
+    # -- Set deployment RollingUpdate max surge
+    surge:
+    # -- Set statefulset RollingUpdate partition
+    partition:
+  # -- ReplicaSet revision history limit
+  revisionHistoryLimit: 3
+
+initContainers:
+  migrate-db:
+    image: "{{ .Values.alpineImage.repository}}:{{ .Values.alpineImage.tag }}"
+    securityContext:
+      runAsUser: 0
+      privileged: true
+      runAsNonRoot: false
+    command:
+      - /bin/sh
+      - -cx
+      - |
+        echo 'trying to migrate old db to new location...'
+        mkdir -p /bitnami/postgresql/data
+        mv -f /bitnami/postgresql/old/* /bitnami/postgresql/data/ || true
+        chown -R {{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }} /bitnami/postgresql/data
+        chmod 775 /bitnami/postgresql/data
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - name: db
+        mountPath: /bitnami/postgresql/old
+      - name: data
+        mountPath: /bitnami/postgresql
+
 securityContext:
   readOnlyRootFilesystem: false
 
@@ -22,6 +66,11 @@ podSecurityContext:
 
 persistence:
   db:
+    enabled: true
+    mountPath: "/bitnami/postgresql"
+
+volumeClaimTemplates:
+  data:
     enabled: true
     mountPath: "/bitnami/postgresql"
 

--- a/charts/dependency/postgresql/values.yaml
+++ b/charts/dependency/postgresql/values.yaml
@@ -13,7 +13,7 @@ controller:
   # For Deployments, valid values are Recreate (default) and RollingUpdate.
   # For StatefulSets, valid values are OnDelete and RollingUpdate (default).
   # DaemonSets ignore this.
-  strategy: Recreate
+  strategy: RollingUpdate
   rollingUpdate:
     # -- Set deployment RollingUpdate max unavailable
     unavailable: 1

--- a/charts/dependency/postgresql/values.yaml
+++ b/charts/dependency/postgresql/values.yaml
@@ -67,7 +67,7 @@ podSecurityContext:
 persistence:
   db:
     enabled: true
-    mountPath: "/bitnami/postgresql"
+    mountPath: "/bitnami/postgresql/old"
 
 volumeClaimTemplates:
   data:

--- a/charts/dependency/redis/Chart.yaml
+++ b/charts/dependency/redis/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
 type: application
-version: 1.0.2
+version: 1.0.3
 annotations:
   truecharts.org/catagories: |
     - database

--- a/charts/dependency/redis/values.yaml
+++ b/charts/dependency/redis/values.yaml
@@ -59,9 +59,6 @@ volumeClaimTemplates:
   data:
     enabled: true
     mountPath: "/bitnami/redis"
-    accessMode: ReadWriteOnce
-    type: pvc
-    size: "100Gi"
 
 # -- Probe configuration
 # -- [[ref]](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)

--- a/charts/stable/openldap/Chart.yaml
+++ b/charts/stable/openldap/Chart.yaml
@@ -23,7 +23,7 @@ sources:
 - https://github.com/jp-gouin/helm-openldap
 - https://github.com/osixia/docker-openldap
 type: application
-version: 4.0.12
+version: 4.0.13
 annotations:
   truecharts.org/catagories: |
     - cloud

--- a/charts/stable/openldap/Chart.yaml
+++ b/charts/stable/openldap/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.5.0"
 dependencies:
 - name: common
   repository: https://truecharts.org
-  version: 8.5.7
+  version: 8.6.1
 deprecated: false
 description: Community developed LDAP software
 home: https://www.openldap.org

--- a/charts/stable/openldap/values.yaml
+++ b/charts/stable/openldap/values.yaml
@@ -95,10 +95,6 @@ volumeClaimTemplates:
   data:
     enabled: true
     mountPath: "/var/lib/ldap/"
-    accessMode: ReadWriteOnce
-    size: "100Gi"
   slapd:
     enabled: true
     mountPath: "/etc/ldap/slapd.d/"
-    accessMode: ReadWriteOnce
-    size: "100Gi"


### PR DESCRIPTION
**Description**
As we want to seamlessly move to a HA postgresql setup, it's imperative to use volumeclaimtemplates instead of PVC with deployments, as the App themselves handles the redundancy instead of the storage backend.

this also patches some inconsistencies with the other dependency app gui's and volumeclaimtemplates in general

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
