### PR TITLE
feat(common): add configmap and secret persistence objects

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.6.5
+version: 8.6.6

--- a/charts/library/common/templates/_configmap.tpl
+++ b/charts/library/common/templates/_configmap.tpl
@@ -1,0 +1,19 @@
+{{/*
+Renders the configMap objects required by the chart.
+*/}}
+{{- define "common.configmap" -}}
+  {{- /* Generate named configMaps as required */ -}}
+  {{- range $name, $configmap := .Values.configmap }}
+    {{- if $configmap.enabled -}}
+      {{- $configmapValues := $configmap -}}
+
+      {{/* set the default nameOverride to the configMap name */}}
+      {{- if not $configmapValues.nameOverride -}}
+        {{- $_ := set $configmapValues "nameOverride" $name -}}
+      {{ end -}}
+
+      {{- $_ := set $ "ObjectValues" (dict "configmap" $configmapValues) -}}
+      {{- include "common.classes.configmap" $ }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/library/common/templates/classes/_configmap.tpl
+++ b/charts/library/common/templates/classes/_configmap.tpl
@@ -1,0 +1,37 @@
+{{/*
+This template serves as a blueprint for all configMap objects that are created
+within the common library.
+*/}}
+{{- define "common.classes.configmap" -}}
+  {{- $fullName := include "common.names.fullname" . -}}
+  {{- $configMapName := $fullName -}}
+  {{- $values := .Values.configmap -}}
+
+  {{- if hasKey . "ObjectValues" -}}
+    {{- with .ObjectValues.configmap -}}
+      {{- $values = . -}}
+    {{- end -}}
+  {{ end -}}
+
+  {{- if and (hasKey $values "nameOverride") $values.nameOverride -}}
+    {{- $configMapName = printf "%v-%v" $configMapName $values.nameOverride -}}
+  {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $configMapName }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    {{- with $values.labels }}
+       {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+{{- with $values.data }}
+  {{- tpl (toYaml .) $ | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/library/common/templates/lib/controller/_volumes.tpl
+++ b/charts/library/common/templates/lib/controller/_volumes.tpl
@@ -34,6 +34,23 @@ Volumes included by the controller.
       {{- $_ := set $emptyDir "sizeLimit" . -}}
     {{- end }}
   emptyDir: {{- $emptyDir | toYaml | nindent 4 }}
+  {{- else if or (eq $persistence.type "configMap") (eq $persistence.type "secret") }}
+    {{- $objectName := (required (printf "objectName not set for persistence item %s" $index) $persistence.objectName) }}
+    {{- $objectName = tpl $objectName $ }}
+    {{- if eq $persistence.type "configMap" }}
+  configMap:
+    name: {{ $objectName }}
+    {{- else }}
+  secret:
+    secretName: {{ $objectName }}
+    {{- end }}
+    {{- with $persistence.defaultMode }}
+    defaultMode: {{ . }}
+    {{- end }}
+    {{- with $persistence.items }}
+    items:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   {{- else if eq $persistence.type "hostPath" }}
   hostPath:
     path: {{ required "hostPath not set" $persistence.hostPath }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -541,6 +541,21 @@ deviceList: []
 # @default -- []
 persistenceList: []
 
+# -- Configure configMaps for the chart here.
+# Additional configMaps can be added by adding a dictionary key similar to the 'config' object.
+# @default -- See below
+configmap:
+  config:
+    # -- Enables or disables the configMap
+    enabled: false
+    # -- Labels to add to the configMap
+    labels: {}
+    # -- Annotations to add to the configMap
+    annotations: {}
+    # -- configMap data content. Helm template enabled.
+    data: {}
+      # foo: bar
+
 # -- Configure persistence for the chart here.
 # Additional items can be added by adding a dictionary key similar to the 'config' key.
 # @default -- See below

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -565,7 +565,7 @@ persistence:
     labels: {}
 
     # -- Sets the persistence type
-    # Valid options are: simplePVC, simpleHP, pvc, emptyDir, hostPath or custom
+    # Valid options are: simplePVC, simpleHP, pvc, emptyDir, secret, configMap, hostPath or custom
     type: pvc
 
     # -- force the complete PVC name
@@ -722,6 +722,40 @@ persistence:
       # configMap:
       #   defaultMode: 420
       #   name: my-settings
+
+  # -- Example of a configmap mount
+  # @default -- See below
+  configmap-example:
+    enabled: false
+    type: configmap
+    # -- Specify the name of the configmap object to be mounted
+    objectName: myconfig-map
+    # -- Where to mount the volume in the main container.
+    # Defaults to `/<name_of_the_volume>`,
+    # setting to '-' creates the volume but disables the volumeMount.
+    mountPath: # /custom-mount
+    # -- Specify if the volume should be mounted read-only.
+    readOnly: false
+
+  # -- Example of a secret mount
+  # @default -- See below
+  secret-example:
+    enabled: false
+    type: secret
+    # -- Specify the name of the secret object to be mounted
+    objectName: mysecret
+    # -- Where to mount the volume in the main container.
+    # Defaults to `/<name_of_the_volume>`,
+    # setting to '-' creates the volume but disables the volumeMount.
+    mountPath: # /custom-mount
+    # -- Specify if the volume should be mounted read-only.
+    readOnly: false
+    # -- define the default mount mode for the secret
+    defaultMode: 777
+    # -- Define the secret items to be mounted
+    items:
+      - key: username
+        path: my-group/my-username
 
 # -- Used in conjunction with `controller.type: statefulset` to create individual disks for each instance.
 volumeClaimTemplates: []


### PR DESCRIPTION
**Description**
This adds configmap and secret support to the persistence section of common.
It solves the issue of continuesly having to inject these in common.yaml on every App

**Type of change**

- [x] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
