### PR TITLE
feat(common): allow for custom selector labels on services.

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.7.1
+version: 8.8.0

--- a/charts/library/common/templates/classes/_service.tpl
+++ b/charts/library/common/templates/classes/_service.tpl
@@ -94,7 +94,11 @@ spec:
   {{- end }}
   {{- if and ( ne $svcType "ExternalName" ) ( ne $svcType "ExternalIP" )}}
   selector:
+  {{- if $values.selector }}
+    {{ toYaml $values.selector | indent 4 }}
+  {{- else }}
     {{- include "common.labels.selectorLabels" . | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- if eq $svcType "ExternalIP" }}
 ---

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -405,6 +405,9 @@ service:
     # -- Override the name suffix that is used for this service
     nameOverride:
 
+    # -- Override default selector
+    selector: {}
+
     # -- Set the service type
     # Options: Simple(Loadbalancer), LoadBalancer, ClusterIP, NodePort
     type: ClusterIP


### PR DESCRIPTION
**Description**
This adds the option to add a custom selector label to a service.
In case we need to use services with dependencies to auto-link them to our portal generator, for example.

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
