### PR TITLE
Update docs to reflect correct default port for unifi guest portal

### DIFF
--- a/docs/manual/default-ports.md
+++ b/docs/manual/default-ports.md
@@ -92,7 +92,7 @@ These defaults can of course be changed, but as we guarantee "sane, working defa
 | gaps                       |       main      |       main      |  8484 |    TCP   |                                         |
 | lidarr                     |       main      |       main      |  8686 |    TCP   |                                         |
 | readarr                    |       main      |       main      |  8787 |    TCP   |                                         |
-| unifi                      |   guestportal   |       web       |  8800 |   HTTP   |                                         |
+| unifi                      |   guestportal   |       web       |  8880 |   HTTP   |                                         |
 | unifi                      |   guestportal   |    websecure    |  8843 |   HTTPS  |                                         |
 | resilio-sync               |       main      |       main      |  8888 |    TCP   |                                         |
 | sonarr                     |       main      |       main      |  8989 |    TCP   |                                         |


### PR DESCRIPTION
**Description**
The default ports documentations has the wrong port for the guest portal of the unifi app.
It should be '8880' instead of '8800'

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
Not much to test as it is only a documentation update.


**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
