### PR TITLE
fix(common): always force a rename and recreate of cert-secrets on update

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.9.4
+version: 8.9.5

--- a/charts/library/common/templates/classes/_ingress.tpl
+++ b/charts/library/common/templates/classes/_ingress.tpl
@@ -85,7 +85,7 @@ spec:
         - {{ tpl . $ | quote }}
         {{- end }}
       {{- if $tlsValues.scaleCert }}
-      secretName: {{ ( printf "%v-%v-%v-%v-%v-%v" $ingressName "tls" $index "ixcert" $tlsValues.scaleCert .Release.Revision ) }}
+      secretName: {{ ( printf "%v-%v-%v-%v-%v-%v" $ingressName "tls" $index "ixcert" $tlsValues.scaleCert $.Release.Revision ) }}
       {{- else if .secretName }}
       secretName: {{ tpl .secretName $ | quote}}
       {{- end }}

--- a/charts/library/common/templates/classes/_ingress.tpl
+++ b/charts/library/common/templates/classes/_ingress.tpl
@@ -85,7 +85,7 @@ spec:
         - {{ tpl . $ | quote }}
         {{- end }}
       {{- if $tlsValues.scaleCert }}
-      secretName: {{ ( printf "%v-%v-%v-%v-%v" $ingressName "tls" $index "ixcert" $tlsValues.scaleCert ) }}
+      secretName: {{ ( printf "%v-%v-%v-%v-%v-%v" $ingressName "tls" $index "ixcert" $tlsValues.scaleCert .Release.Revision ) }}
       {{- else if .secretName }}
       secretName: {{ tpl .secretName $ | quote}}
       {{- end }}

--- a/charts/library/common/templates/lib/cert/_certSecret.tpl
+++ b/charts/library/common/templates/lib/cert/_certSecret.tpl
@@ -20,7 +20,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secretName }}
+  name: {{ $secretName }}-{{ .Release.Revision }}
   labels: {{ include "common.labels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:

--- a/tests/library/common/cert_spec.rb
+++ b/tests/library/common/cert_spec.rb
@@ -88,7 +88,7 @@ class Test < ChartTest
         chart.value values
         refute_nil(resource('Secret'))
         secret = chart.resources(kind: "Secret").first
-        assert_equal("common-test-tls-0-ixcert-1", secret["metadata"]["name"])
+        assert_equal("common-test-tls-0-ixcert-1-1", secret["metadata"]["name"])
         refute_nil(secret["data"]["tls.crt"])
         refute_nil(secret["data"]["tls.key"])
       end
@@ -166,13 +166,13 @@ class Test < ChartTest
         chart.value values
         refute_nil(resource('Secret'))
         secret = chart.resources(kind: "Secret").first
-        assert_equal("common-test-tls-0-ixcert-1", secret["metadata"]["name"])
+        assert_equal("common-test-tls-0-ixcert-1-1", secret["metadata"]["name"])
         refute_nil(secret["data"]["tls.crt"])
         refute_nil(secret["data"]["tls.key"])
 
         ingress = chart.resources(kind: "Ingress").find{ |s| s["metadata"]["name"] == "common-test" }
         refute_nil(ingress)
-        assert_equal("common-test-tls-0-ixcert-1", ingress["spec"]["tls"][0]["secretName"])
+        assert_equal("common-test-tls-0-ixcert-1-1", ingress["spec"]["tls"][0]["secretName"])
       end
       it 'multiple tls sections generate multiple secrets' do
         values = {
@@ -304,18 +304,18 @@ class Test < ChartTest
         chart.value values
         refute_nil(resource('Secret'))
         secret1 = chart.resources(kind: "Secret").first
-        assert_equal("common-test-tls-0-ixcert-1", secret1["metadata"]["name"])
+        assert_equal("common-test-tls-0-ixcert-1-1", secret1["metadata"]["name"])
         refute_nil(secret1["data"]["tls.crt"])
         refute_nil(secret1["data"]["tls.key"])
-        secret2 = chart.resources(kind: "Secret").find{ |s| s["metadata"]["name"] == "common-test-tls-1-ixcert-2" }
+        secret2 = chart.resources(kind: "Secret").find{ |s| s["metadata"]["name"] == "common-test-tls-1-ixcert-2-1" }
         refute_nil(secret2)
         refute_nil(secret2["data"]["tls.crt"])
         refute_nil(secret2["data"]["tls.key"])
 
         ingress = chart.resources(kind: "Ingress").find{ |s| s["metadata"]["name"] == "common-test" }
         refute_nil(ingress)
-        assert_equal("common-test-tls-0-ixcert-1", ingress["spec"]["tls"][0]["secretName"])
-        assert_equal("common-test-tls-1-ixcert-2", ingress["spec"]["tls"][1]["secretName"])
+        assert_equal("common-test-tls-0-ixcert-1-1", ingress["spec"]["tls"][0]["secretName"])
+        assert_equal("common-test-tls-1-ixcert-2-1", ingress["spec"]["tls"][1]["secretName"])
       end
     end
   end


### PR DESCRIPTION
**Description**
Traefik seems to have some minor issues with refreshing certificates.
This is a nuke to at least force it to always fetch a new secret.

**Type of change**

- [ ] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
