### PR TITLE
Fix questinaire for vaultwarden

### DIFF
--- a/charts/stable/vaultwarden/questions.yaml
+++ b/charts/stable/vaultwarden/questions.yaml
@@ -259,7 +259,7 @@ questions:
                       schema:
                         type: string
                         default: ""
-                    - variable: port
+                    - variable: timeout
                       label: "SMTP timeout"
                       schema:
                         type: int


### PR DESCRIPTION
Bug https://github.com/truecharts/apps/issues/1437

Verified just the questionaire is wrong, config is correctly pointing to timeout variable.