### PR TITLE
chore(apps): set PUID to `int` instead of `string`

### DIFF
--- a/charts/stable/booksonic-air/questions.yaml
+++ b/charts/stable/booksonic-air/questions.yaml
@@ -84,8 +84,8 @@ questions:
           label: "PUID"
           description: "Sets the userID inside the container"
           schema:
-            type: string
-            default: "568"
+            type: int
+            default: 568
 
 
 # Include{containerConfig}

--- a/charts/stable/hyperion-ng/questions.yaml
+++ b/charts/stable/hyperion-ng/questions.yaml
@@ -84,8 +84,8 @@ questions:
           label: "PUID"
           description: "Sets the userID inside the container"
           schema:
-            type: string
-            default: "568"
+            type: int
+            default: 568
 
 
 # Include{containerConfig}

--- a/charts/stable/librespeed/questions.yaml
+++ b/charts/stable/librespeed/questions.yaml
@@ -84,8 +84,8 @@ questions:
           label: "PUID"
           description: "Sets the userID inside the container"
           schema:
-            type: string
-            default: "568"
+            type: int
+            default: 568
 
 
 # Include{containerConfig}

--- a/charts/stable/mylar/questions.yaml
+++ b/charts/stable/mylar/questions.yaml
@@ -84,8 +84,8 @@ questions:
           label: "PUID"
           description: "Sets the userID inside the container"
           schema:
-            type: string
-            default: "568"
+            type: int
+            default: 568
 
 
 # Include{containerConfig}

--- a/charts/stable/oscam/questions.yaml
+++ b/charts/stable/oscam/questions.yaml
@@ -85,8 +85,8 @@ questions:
           label: "PUID"
           description: "Sets the userID inside the container"
           schema:
-            type: string
-            default: "568"
+            type: int
+            default: 568
 
 
 # Include{containerConfig}

--- a/charts/stable/pyload/questions.yaml
+++ b/charts/stable/pyload/questions.yaml
@@ -84,8 +84,8 @@ questions:
           label: "PUID"
           description: "Sets the userID inside the container"
           schema:
-            type: string
-            default: "568"
+            type: int
+            default: 568
 
 
 # Include{containerConfig}

--- a/charts/stable/resilio-sync/questions.yaml
+++ b/charts/stable/resilio-sync/questions.yaml
@@ -84,8 +84,8 @@ questions:
           label: "PUID"
           description: "Sets the userID inside the container"
           schema:
-            type: string
-            default: "568"
+            type: int
+            default: 568
 
 
 # Include{containerConfig}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Fixes # <!--(issue)-->

**Type of change**

- [ ] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
