### PR TITLE
fix(scrutiny): fix storage and envs

### DIFF
--- a/charts/stable/scrutiny/questions.yaml
+++ b/charts/stable/scrutiny/questions.yaml
@@ -82,7 +82,29 @@ questions:
       type: dict
       attrs:
 # Include{fixedEnv}
-
+        - variable: GIN_MODE
+          label: "GIN_MODE"
+          schema:
+            type: string
+            default: "release"
+            required: true
+            enum:
+              - value: "release"
+                description: "release"
+              - value: "debug"
+                description: "debug"
+        - variable: SCRUTINY_WEB
+          label: "SCRUTINY_WEB"
+          description: "SCRUTINY_WEB"
+          schema:
+            type: boolean
+            default: true
+        - variable: SCRUTINY_COLLECTOR
+          label: "SCRUTINY_COLLECTOR"
+          description: "SCRUTINY_COLLECTOR"
+          schema:
+            type: boolean
+            default: true
 # Include{containerConfig}
 
   - variable: service
@@ -232,6 +254,62 @@ questions:
                     - value: "Memory"
                       description: "Memory"
 # Include{persistenceAdvanced}
+        - variable: data
+          label: "App data Storage"
+          description: "Stores the Application data."
+          schema:
+            type: dict
+            attrs:
+              - variable: enabled
+                label: "Enable the storage"
+                schema:
+                  type: boolean
+                  default: true
+                  hidden: true
+              - variable: type
+                label: "Type of Storage"
+                description: "Sets the persistence type, Anything other than PVC could break rollback!"
+                schema:
+                  type: string
+                  default: "simplePVC"
+                  enum:
+                    - value: "simplePVC"
+                      description: "PVC (simple)"
+                    - value: "simpleHP"
+                      description: "HostPath (simple)"
+                    - value: "emptyDir"
+                      description: "emptyDir"
+                    - value: "pvc"
+                      description: "pvc"
+                    - value: "hostPath"
+                      description: "hostPath"
+# Include{persistenceBasic}
+              - variable: hostPath
+                label: "hostPath"
+                description: "Path inside the container the storage is mounted"
+                schema:
+                  show_if: [["type", "=", "hostPath"]]
+                  type: hostpath
+              - variable: mountPath
+                label: "mountPath"
+                description: "Path inside the container the storage is mounted"
+                schema:
+                  type: string
+                  default: "/config"
+                  hidden: true
+                  valid_chars: '^\/([a-zA-Z0-9._-]+(\s?[a-zA-Z0-9._-]+|\/?))+$'
+              - variable: medium
+                label: "EmptyDir Medium"
+                schema:
+                  show_if: [["type", "=", "emptyDir"]]
+                  type: string
+                  default: ""
+                  enum:
+                    - value: ""
+                      description: "Default"
+                    - value: "Memory"
+                      description: "Memory"
+# Include{persistenceAdvanced}
 
 # Include{persistenceList}
 
@@ -278,7 +356,7 @@ questions:
                 label: "ReadOnly Root Filesystem"
                 schema:
                   type: boolean
-                  default: true
+                  default: false
               - variable: allowPrivilegeEscalation
                 label: "Allow Privilege Escalation"
                 schema:

--- a/charts/stable/scrutiny/values.yaml
+++ b/charts/stable/scrutiny/values.yaml
@@ -7,6 +7,7 @@ securityContext:
   runAsNonRoot: false
   privileged: true
   allowPrivilegeEscalation: true
+  readOnlyRootFilesystem: false
 
 podSecurityContext:
   runAsUser: 0
@@ -14,6 +15,9 @@ podSecurityContext:
 
 env:
   PUID: 568
+  SCRUTINY_WEB: true
+  SCRUTINY_COLLECTOR: true
+  SCRUTINY_API_ENDPOINT: "http://localhost:8080"
 
 service:
   main:
@@ -28,6 +32,9 @@ persistence:
   config:
     enabled: true
     mountPath: "/scrutiny/config"
+  data:
+    enabled: true
+    mountPath: "/config"
   udev:
     type: hostPath
     hostPath: /run/udev


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Fixes # <!--(issue)-->

---

Looks like this app saves
- configs on `/scrutiny/config`
- data (like its sqlite db) on `/config`
![image](https://user-images.githubusercontent.com/47820033/145888484-15914e91-4a91-4af6-999f-9c735258f370.png)


Also while on lsio docs seems like the set `SCRUTINY_WEB` and `SCRUTINY_COLLECTOR` envs to `true` by default. it's not the case, so they need to be manually set.

`SCRUTINY_API_ENDPOINT` should not be needed to change, unless a remote collector is used.
`GIN_MODE` is set now set by default to `release` instead of `debug` but there is a GUI option to change it if needed.

Also need access to root fs...

---
**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
