### PR TITLE
fix(deepstack): default to pvc for modelstore

### DIFF
--- a/charts/stable/deepstack-cpu/Chart.yaml
+++ b/charts/stable/deepstack-cpu/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://hub.docker.com/r/deepquestai/deepstack
 - https://www.deepstack.cc/
 type: application
-version: 8.0.4
+version: 8.0.5
 annotations:
   truecharts.org/catagories: |
     - AI

--- a/charts/stable/deepstack-cpu/questions.yaml
+++ b/charts/stable/deepstack-cpu/questions.yaml
@@ -284,7 +284,7 @@ questions:
                 description: "Sets the persistence type, Anything other than PVC could break rollback!"
                 schema:
                   type: string
-                  default: "simpleHP"
+                  default: "simplePVC"
                   enum:
                     - value: "simplePVC"
                       description: "PVC (simple)"

--- a/charts/stable/deepstack-gpu/Chart.yaml
+++ b/charts/stable/deepstack-gpu/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://hub.docker.com/r/deepquestai/deepstack
 - https://www.deepstack.cc/
 type: application
-version: 3.0.4
+version: 3.0.5
 annotations:
   truecharts.org/catagories: |
     - AI

--- a/charts/stable/deepstack-gpu/questions.yaml
+++ b/charts/stable/deepstack-gpu/questions.yaml
@@ -284,7 +284,7 @@ questions:
                 description: "Sets the persistence type, Anything other than PVC could break rollback!"
                 schema:
                   type: string
-                  default: "simpleHP"
+                  default: "simplePVC"
                   enum:
                     - value: "simplePVC"
                       description: "PVC (simple)"


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Fixes # <!--(issue)-->
While `modelstore` will be mostly used as `hostPath`, it's not needed for the app to function.
But if left as `hostPath` user have to define a host path, in order the app to install/upgrade.

Normally this would be completely removed and only added as a custom storage, but then the user would have to also set an env var to define the path. 
Currently we set this path like this:
`MODELSTORE-DETECTION: "{{ .Values.persistence.modelstore.mountPath }}"`

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
