### PR TITLE
Fix: InfluxDB is always disabled with current value.

### DIFF
--- a/charts/stable/unpoller/Chart.yaml
+++ b/charts/stable/unpoller/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://github.com/unifi-poller/unifi-poller
 - https://hub.docker.com/r/golift/unifi-poller
 type: application
-version: 1.0.15
+version: 1.0.17
 annotations:
   truecharts.org/catagories: |
     - metrics

--- a/charts/stable/unpoller/values.yaml
+++ b/charts/stable/unpoller/values.yaml
@@ -15,7 +15,7 @@ env:
   # UP_UNIFI_DEFAULT_USER: "unifipoller"
   # UP_UNIFI_DEFAULT_PASS: "unifipoller"
   UP_PROMETHEUS_DISABLE: false
-  UP_INFLUXDB_DISABLE: true
+  UP_INFLUXDB_DISABLE: false
 
 service:
   main:

--- a/charts/stable/unpoller/values.yaml
+++ b/charts/stable/unpoller/values.yaml
@@ -15,7 +15,6 @@ env:
   # UP_UNIFI_DEFAULT_USER: "unifipoller"
   # UP_UNIFI_DEFAULT_PASS: "unifipoller"
   UP_PROMETHEUS_DISABLE: false
-  UP_INFLUXDB_DISABLE: false
 
 service:
   main:


### PR DESCRIPTION
**Describe the bug**
You set all env variables to enable InfluxDB, set username, password, host, database name, etc. Or you use the config file to configure all the InfluxDB information.
Once the pod starts, it will always have InfluxDB as disabled because the Helm values are always set to: `UP_INFLUXDB_DISABLE: true`

**To Reproduce**
Create a new unpoller with InfluxDB env variables OR config file. Make sure you have `UP_INFLUXDB_DISABLE: false`.
Once pod starts, check the value for the `UP_INFLUXDB_DISABLE` env variable. It will be `true` instead of `false` and no logs will be uploaded to the InfluxDB host you configured.

**Type of change**

- [x] Bugfix
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


**How Has This Been Tested?**
I have manually edited the deployment yaml and configured the env variable `UP_INFLUXDB_DISABLE` to `false`. Once new pod came online, it started sending data to InfluxDB host.

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
