### PR TITLE
fix(paperless-ng): don't change default dir for static

### DIFF
--- a/charts/stable/paperless-ng/questions.yaml
+++ b/charts/stable/paperless-ng/questions.yaml
@@ -247,48 +247,6 @@ questions:
                     - value: "Memory"
                       description: "Memory"
 # Include{persistenceAdvanced}
-        - variable: static
-          label: "App Static Storage"
-          description: "This is where all static files created using “collectstatic” manager command are stored."
-          schema:
-            type: dict
-            attrs:
-              - variable: type
-                label: "Type of Storage"
-                description: "Sets the persistence type, Anything other than PVC could break rollback!"
-                schema:
-                  type: string
-                  default: "simplePVC"
-                  enum:
-                    - value: "simplePVC"
-                      description: "PVC (simple)"
-                    - value: "simpleHP"
-                      description: "HostPath (simple)"
-                    - value: "emptyDir"
-                      description: "emptyDir"
-                    - value: "pvc"
-                      description: "pvc"
-                    - value: "hostPath"
-                      description: "hostPath"
-# Include{persistenceBasic}
-              - variable: hostPath
-                label: "hostPath"
-                description: "Path inside the container the storage is mounted"
-                schema:
-                  show_if: [["type", "=", "hostPath"]]
-                  type: hostpath
-              - variable: medium
-                label: "EmptyDir Medium"
-                schema:
-                  show_if: [["type", "=", "emptyDir"]]
-                  type: string
-                  default: ""
-                  enum:
-                    - value: ""
-                      description: "Default"
-                    - value: "Memory"
-                      description: "Memory"
-# Include{persistenceAdvanced}
         - variable: consume
           label: "To-be consumed Document Storage"
           description: "This where your documents should go to be consumed."

--- a/charts/stable/paperless-ng/values.yaml
+++ b/charts/stable/paperless-ng/values.yaml
@@ -19,7 +19,6 @@ secret:
 env:
   PUID: 568
   PAPERLESS_DATA_DIR: "/data/"
-  PAPERLESS_STATICDIR: "/static/"
   PAPERLESS_CONSUMPTION_DIR: "/consume/"
   PAPERLESS_MEDIA_ROOT: "/media/"
   USERMAP_UID: "{{ .Values.env.PUID }}"
@@ -61,9 +60,6 @@ persistence:
   consume:
     enabled: true
     mountPath: "/consume"
-  static:
-    enabled: true
-    mountPath: "/static"
   media:
     enabled: true
     mountPath: "/media"


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Fixes # <!--(issue)-->

Changing static dir location, causes app to not load any CSS files and possibly js files aswell. 

As they mention on their docs:

---

**Unless you’re doing something fancy, there is no need to override this.**

---

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
