### PR TITLE
feat(traefik): allow port-based redirect and move redirect to advanced settings.

### DIFF
--- a/charts/core/traefik/questions.yaml
+++ b/charts/core/traefik/questions.yaml
@@ -584,6 +584,12 @@ questions:
                       schema:
                         type: dict
                         attrs:
+                          - variable: port
+                            label: "Entrypoints Port"
+                            schema:
+                              type: int
+                              default: 9080
+                              required: true
                           - variable: advanced
                             label: "Show Advanced settings"
                             schema:
@@ -617,23 +623,26 @@ questions:
                                   description: "The internal(!) port on the container the Application runs on"
                                   schema:
                                     type: int
-                                    default: 9080
-                          - variable: port
-                            label: "Entrypoints Port"
-                            schema:
-                              type: int
-                              default: 9080
-                              required: true
-                          - variable: redirectTo
-                            label: "Redirect to"
-                            schema:
-                              type: string
-                              default: "websecure"
+                                - variable: redirectPort
+                                  label: "Redirect to Port"
+                                  schema:
+                                    type: int
+                                - variable: redirectTo
+                                  label: "Redirect to Entrypoint"
+                                  schema:
+                                    type: string
+                                    default: "websecure"
                     - variable: websecure
                       label: "websecure Entrypoints Configuration"
                       schema:
                         type: dict
                         attrs:
+                          - variable: port
+                            label: "Entrypoints Port"
+                            schema:
+                              type: int
+                              default: 9443
+                              required: true
                           - variable: advanced
                             label: "Show Advanced settings"
                             schema:
@@ -667,13 +676,14 @@ questions:
                                   description: "The internal(!) port on the container the Application runs on"
                                   schema:
                                     type: int
-                                    default: 9443
-                          - variable: port
-                            label: "Entrypoints Port"
-                            schema:
-                              type: int
-                              default: 9443
-                              required: true
+                                - variable: redirectPort
+                                  label: "Redirect to Port"
+                                  schema:
+                                    type: int
+                                - variable: redirectTo
+                                  label: "Redirect to Entrypoint"
+                                  schema:
+                                    type: string
                           - variable: tls
                             label: "websecure Entrypoints Configuration"
                             schema:
@@ -736,6 +746,14 @@ questions:
                                   schema:
                                     type: boolean
                                     default: true
+                                - variable: redirectPort
+                                  label: "Redirect to Port"
+                                  schema:
+                                    type: int
+                                - variable: redirectTo
+                                  label: "Redirect to Entrypoint"
+                                  schema:
+                                    type: string
         - variable: metrics
           label: "metrics Service"
           description: "The metrics Entrypoint service"

--- a/charts/core/traefik/templates/_args.tpl
+++ b/charts/core/traefik/templates/_args.tpl
@@ -68,6 +68,11 @@ args:
   {{- $toPort := index $ports $config.redirectTo }}
   - "--entrypoints.{{ $entrypoint }}.http.redirections.entryPoint.to=:{{ $toPort.port }}"
   - "--entrypoints.{{ $entrypoint }}.http.redirections.entryPoint.scheme=https"
+  {{- else if $config.redirectPort }}
+  {{ if gt $config.redirectPort 0.0 }}
+  - "--entrypoints.{{ $entrypoint }}.http.redirections.entryPoint.to=:{{ $config.redirectPort }}"
+  - "--entrypoints.{{ $entrypoint }}.http.redirections.entryPoint.scheme=https"
+  {{- end }}
   {{- end }}
   {{- if or ( $config.tls ) ( eq $config.protocol "HTTPS" ) }}
   {{- if or ( $config.tls.enabled ) ( eq $config.protocol "HTTPS" ) }}

--- a/charts/core/traefik/values.yaml
+++ b/charts/core/traefik/values.yaml
@@ -150,6 +150,8 @@ service:
         port: 9080
         protocol: HTTP
         redirectTo: websecure
+        # Options: Empty, 0 (ingore), or positive int
+        # redirectPort:
       websecure:
         enabled: true
         port: 9443


### PR DESCRIPTION
**Description**
There is an issue in the SCALE webui where it doesn't accept strings starting with `:`. It makes it impossible to set port-based entrypoint redirects in traefik. This PRadds a seperate field for port-based redirects and moves those to advanced settings as well.

Also moves port in the gui and removes setting targetPort by default

**Type of change**

- [X] Feature/App addition
- [X] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
