### PR TITLE
chore(apps): move `port` up in gui

### DIFF
--- a/charts/stable/apache-musicindex/questions.yaml
+++ b/charts/stable/apache-musicindex/questions.yaml
@@ -102,6 +102,13 @@ questions:
                       schema:
                         type: dict
                         attrs:
+                          - variable: port
+                            label: "Port"
+                            description: "This port exposes the container port on the service"
+                            schema:
+                              type: int
+                              default: 10006
+                              required: true
                           - variable: advanced
                             label: "Show Advanced settings"
                             schema:
@@ -136,13 +143,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 80
-                          - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
-                            schema:
-                              type: int
-                              default: 10006
-                              required: true
 
   - variable: serviceexpert
     group: "Networking and Services"

--- a/charts/stable/collabora-online/Chart.yaml
+++ b/charts/stable/collabora-online/Chart.yaml
@@ -22,7 +22,7 @@ sources:
 - https://sdk.collaboraonline.com/contents.html
 - https://github.com/CollaboraOnline/online/tree/master/kubernetes/helm
 type: application
-version: 10.0.7
+version: 10.0.8
 annotations:
   truecharts.org/catagories: |
     - office

--- a/charts/stable/grafana/questions.yaml
+++ b/charts/stable/grafana/questions.yaml
@@ -143,6 +143,13 @@ questions:
                       schema:
                         type: dict
                         attrs:
+                          - variable: port
+                            label: "Port"
+                            description: "This port exposes the container port on the service"
+                            schema:
+                              type: int
+                              default: 10038
+                              required: true
                           - variable: advanced
                             label: "Show Advanced settings"
                             schema:
@@ -182,13 +189,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 3000
-                          - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
-                            schema:
-                              type: int
-                              default: 10038
-                              required: true
 
   - variable: serviceexpert
     group: "Networking and Services"

--- a/charts/stable/jackett/questions.yaml
+++ b/charts/stable/jackett/questions.yaml
@@ -103,6 +103,13 @@ questions:
                       schema:
                         type: dict
                         attrs:
+                          - variable: port
+                            label: "Port"
+                            description: "This port exposes the container port on the service"
+                            schema:
+                              type: int
+                              default: 9117
+                              required: true
                           - variable: advanced
                             label: "Show Advanced settings"
                             schema:
@@ -142,13 +149,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 9117
-                          - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
-                            schema:
-                              type: int
-                              default: 9117
-                              required: true
 
   - variable: serviceexpert
     group: "Networking and Services"

--- a/charts/stable/loki/questions.yaml
+++ b/charts/stable/loki/questions.yaml
@@ -159,6 +159,13 @@ questions:
                       schema:
                         type: dict
                         attrs:
+                          - variable: port
+                            label: "Port"
+                            description: "This port exposes the container port on the service"
+                            schema:
+                              type: int
+                              default: 3100
+                              required: true
                           - variable: advanced
                             label: "Show Advanced settings"
                             schema:
@@ -198,13 +205,6 @@ questions:
                                   schema:
                                     type: int
                                     default: 3100
-                          - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
-                            schema:
-                              type: int
-                              default: 3100
-                              required: true
 
   - variable: serviceexpert
     group: "Networking and Services"

--- a/charts/stable/oscam/Chart.yaml
+++ b/charts/stable/oscam/Chart.yaml
@@ -19,7 +19,7 @@ name: oscam
 sources:
 - https://trac.streamboard.tv/oscam/browser/trunk
 type: application
-version: 4.0.26
+version: 4.0.27
 annotations:
   truecharts.org/catagories: |
     - DIY

--- a/charts/stable/oscam/questions.yaml
+++ b/charts/stable/oscam/questions.yaml
@@ -109,6 +109,13 @@ questions:
                       schema:
                         type: dict
                         attrs:
+                          - variable: port
+                            label: "Port"
+                            description: "This port exposes the container port on the service"
+                            schema:
+                              type: int
+                              default: 10062
+                              required: true
                           - variable: advanced
                             label: "Show Advanced settings"
                             schema:
@@ -144,20 +151,6 @@ questions:
                                     type: int
                                     default: 8888
                               required: true
-                          - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
-                            schema:
-                              type: int
-                              default: 10062
-                              required: true
-                          - variable: nodePort
-                            label: "Node Port (Optional)"
-                            description: "This port gets exposed to the node. Only considered when service type is NodePort"
-                            schema:
-                              type: int
-                              min: 9000
-                              max: 65535
 
   - variable: serviceexpert
     group: "Networking and Services"


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Fixes # <!--(issue)-->
Moves `port` up in the GUI as we done with the rest of the apps. Those seem to slipped. Also remove duplicate `nodePort` from oscam
**Type of change**

- [ ] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
