### PR TITLE
feat(common): add support for a, renovate compatible, image selector

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.9.27
+version: 8.10.0

--- a/charts/library/common/templates/lib/controller/_container.tpl
+++ b/charts/library/common/templates/lib/controller/_container.tpl
@@ -1,7 +1,7 @@
 {{- /* The main container included in the controller */ -}}
 {{- define "common.controller.mainContainer" -}}
 - name: {{ include "common.names.fullname" . }}
-  image: {{ printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) | quote }}
+  image: {{ include "common.images.selector" . }}
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   {{- with .Values.command }}
   command:

--- a/charts/library/common/templates/lib/utils/_images.tpl
+++ b/charts/library/common/templates/lib/utils/_images.tpl
@@ -10,6 +10,21 @@ Return the proper image name
 {{- end -}}
 
 {{/*
+Return the image name using the selector
+{{ include "common.images.selector" . }}
+*/}}
+{{- define "common.images.selector" -}}
+{{- $imageDict := get .Values "image" }}
+{{- $selected := .Values.imageSelector }}
+{{- if hasKey .Values $selected }}
+{{- $imageDict = get .Values $selected }}
+{{- end }}
+{{- $repositoryName := $imageDict.repository -}}
+{{- $tag :=$imageDict.tag | toString -}}
+{{- printf "%s:%s" $repositoryName $tag -}}
+{{- end -}}
+
+{{/*
 Return the proper Docker Image Registry Secret Names (deprecated: use common.images.renderPullSecrets instead)
 {{ include "common.images.pullSecrets" ( dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "global" .Values.global) }}
 */}}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -119,6 +119,10 @@ image:
   # -- image pull policy
   pullPolicy:
 
+# -- Image Selector allows for easy picking a different image dict, important for the SCALE GUI
+imageSelector: "image"
+
+
 # -- Override the command(s) for the default container
 command: []
 # -- Override the args for the default container


### PR DESCRIPTION
**Description**
There where many requests for supporting multiple image "trains"/"versions"/"tags" on the same App.
There are caveats with that, as it needs to stay within the compatibility of our auto-updater (renovate), has to be native Helm compatible and has to be process(able) by the test suit.

This change adds an "imageSelector" variable, that contains the name of the root level dict containing the selected image configuration. This can easily be added to an enum in the TrueNAS SCALE UI.

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
The existing test suit has not been altered.
Rendering of the selectedImage has been done manually.

As currently the functionality is not used, it's only important to guarantee compatibility with the current way of handling images at this stage

The test and PoC App will be submitted in another PR.

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
