### PR TITLE
docs: add hostname command to linking guide

### DIFF
--- a/docs/manual/Quick-Start Guides/06-linking-apps.md
+++ b/docs/manual/Quick-Start Guides/06-linking-apps.md
@@ -8,6 +8,8 @@ The backend for TrueNAS SCALE Apps is Kubernetes. Linking apps together in Kuber
 
 Instead we need to use their internal(!) domain name. Please beware: this name is only available between Apps and can not be reached from the host/node or your own PC.
 
+The internal domain name can be discovered by opening a shell in the desired pod and executing: `hostname -f`
+
 The format for internal domain name for the main service is explained bellow.
 Please replace `$NAME` with the name you gave your App when installing and `$APP` with the name the app has on the catalog where is needed.
 


### PR DESCRIPTION
**Description**
This adds a simple way of finding the correct hostname to the documentation page "Linking Apps Internally".

> The internal domain name can be discovered by opening a shell in the desired pod and executing: `hostname -f`

**Type of change**

- [ ] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code
- [X] Documentation

**How Has This Been Tested?**


**Notes:**


**Checklist:**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
