### PR TITLE
fix(friendica): Add envs, to make first setup automatic

### DIFF
--- a/charts/stable/friendica/Chart.yaml
+++ b/charts/stable/friendica/Chart.yaml
@@ -27,7 +27,7 @@ name: friendica
 sources:
   - https://friendi.ca/
   - https://hub.docker.com/_/friendica
-version: 0.0.22
+version: 0.0.23
 annotations:
   truecharts.org/catagories: |
     - social

--- a/charts/stable/friendica/questions.yaml
+++ b/charts/stable/friendica/questions.yaml
@@ -82,7 +82,20 @@ questions:
       type: dict
       attrs:
 # Include{fixedEnv}
-
+        - variable: FRIENDICA_ADMIN_MAIL
+          label: "Admin E-Mail"
+          description: "E-Mail address of the administrator."
+          schema:
+            type: string
+            required: true
+            default:
+        - variable: FRIENDICA_URL
+          label: "Friendica URL"
+          description: "The Friendica complete URL including protocol, domain and subpath (example: https://friendica.local/sub/ )."
+          schema:
+            type: string
+            required: true
+            default:
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/friendica/questions.yaml
+++ b/charts/stable/friendica/questions.yaml
@@ -88,14 +88,14 @@ questions:
           schema:
             type: string
             required: true
-            default:
+            default: ""
         - variable: FRIENDICA_URL
           label: "Friendica URL"
           description: "The Friendica complete URL including protocol, domain and subpath (example: https://friendica.local/sub/ )."
           schema:
             type: string
             required: true
-            default:
+            default: ""
 # Include{containerConfig}
 
   - variable: service

--- a/charts/stable/friendica/values.yaml
+++ b/charts/stable/friendica/values.yaml
@@ -15,6 +15,8 @@ podSecurityContext:
 env:
   MYSQL_USER: friendica
   MYSQL_DATABASE: friendica
+  FRIENDICA_ADMIN_MAIL: "my@domain.com"
+  FRIENDICA_URL: "https://friendica.local"
 
 service:
   main:


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Fixes #1655

According to their documentation (https://hub.docker.com/_/friendica), To achieve automatic install you need those two env's as well.

NOTE: On the automatic install you can't select to offer self signed certs as it's intended to be used behind reverse proxy and be served over HTTPS. That means while it will be installed, it won't work without ingress/reverse proxy. 

Manual testing only got me to login screen with HTTP, and logs shows successful automatic install. Didn't test with ingress but should work, as after login it redirects to HTTPS.

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
