### PR TITLE
fix(fireflyiii): Actually render env on cronjob and revert port change

### DIFF
--- a/charts/stable/fireflyiii/Chart.yaml
+++ b/charts/stable/fireflyiii/Chart.yaml
@@ -28,7 +28,7 @@ name: fireflyiii
 sources:
 - https://github.com/firefly-iii/firefly-iii/
 type: application
-version: 13.1.11
+version: 13.1.12
 annotations:
   truecharts.org/catagories: |
     - finacial

--- a/charts/stable/fireflyiii/templates/_cronjob.tpl
+++ b/charts/stable/fireflyiii/templates/_cronjob.tpl
@@ -47,7 +47,7 @@ spec:
               image: "{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
               args:
               - curl
-              - "http://{{ $jobName }}.ix-{{ .Release.Name }}.svc.cluster.local:{{ .Values.service.main.ports.main.targetPort }}/api/v1/cron/$STATIC_CRON_TOKEN"
+              - "http://{{ $jobName }}.ix-{{ .Release.Name }}.svc.cluster.local:{{ .Values.service.main.ports.main.port }}/api/v1/cron/$(STATIC_CRON_TOKEN)"
               resources:
 {{ toYaml .Values.resources | indent 16 }}
 


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Fixes # <!--(issue)-->
I thought that when using internal dns names for pods it would use `targetPort`, but it does not seem to be the case.
e.g. From the same deployment got into the redis shell and did:

- `curl validinternaldnsname:8080` and got connection refused
- `curl validinternaldnsname:10082` and got back the login page.

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
