### PR TITLE
fix(calibre): Replace deprecated env's and fix port

### DIFF
--- a/charts/stable/calibre/Chart.yaml
+++ b/charts/stable/calibre/Chart.yaml
@@ -18,7 +18,7 @@ name: calibre
 sources:
 - https://hub.docker.com/r/linuxserver/calibre/
 - https://github.com/kovidgoyal/calibre/
-version: 5.0.9
+version: 5.0.10
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/calibre/questions.yaml
+++ b/charts/stable/calibre/questions.yaml
@@ -79,19 +79,13 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: GUAC_USER
-          label: "GUAC_USER"
-          description: "Username for the calibre gui"
-          schema:
-            type: string
-            default: "REPLACETHIS"
-        - variable: GUAC_PASS
-          label: "GUAC_PASS"
-          description: "Password's md5 hash for the calibre gui"
+        - variable: PASSWORD
+          label: "PASSWORD"
+          description: "Optionally set a password for the gui."
           schema:
             type: string
             private: true
-            default: "REPLACETHIS"
+            default: ""
   - variable: env
     group: "Container Configuration"
     label: "Image Environment"
@@ -136,7 +130,7 @@ questions:
                             description: "This port exposes the container port on the service"
                             schema:
                               type: int
-                              default: 10080
+                              default: 8084
                               required: true
                           - variable: advanced
                             label: "Show Advanced settings"

--- a/charts/stable/calibre/values.yaml
+++ b/charts/stable/calibre/values.yaml
@@ -1,9 +1,6 @@
 image:
-  # -- image repository
   repository: tccr.io/truecharts/calibre
-  # -- image tag
   tag: v5.32.0-ls138@sha256:a7c6272300628eb747dc129001aef8bc53d9b462ebe6b4953de904a2a5e15c8e
-  # -- image pull policy
   pullPolicy: IfNotPresent
 
 securityContext:
@@ -15,27 +12,18 @@ podSecurityContext:
   runAsGroup: 0
 
 secret:
-  # -- Username for the calibre gui
-  GUAC_USER: ""
-  # -- Password's md5 hash for the calibre gui
-  GUAC_PASS: ""
-# -- environment variables. See [image docs](https://docs.linuxserver.io/images/docker-calibre#environment-variables-e) for more details.
-# @default -- See below
+  PASSWORD: ""
+
 env:
-  # -- Set the container timezone
   TZ: UTC
-  # -- Specify the user ID the application will run as
   PUID: 568
-  # -- Optionally pass cli start arguments to calibre.
   CLI_ARGS:
 
-# -- Configures service settings for the chart.
-# @default -- See values.yaml
 service:
   main:
     ports:
       main:
-        port: 10080
+        port: 8084
         targetPort: 8080
   webserver:
     enabled: true
@@ -45,8 +33,6 @@ service:
         port: 8081
         targetPort: 8081
 
-# -- Configure persistence settings for the chart under this key.
-# @default -- See values.yaml
 persistence:
   config:
     enabled: true

--- a/docs/manual/default-ports.md
+++ b/docs/manual/default-ports.md
@@ -102,7 +102,8 @@ These defaults can of course be changed, but as we guarantee "sane, working defa
 | unifi                      |      comm       |      comm       | 8080  |   TCP    |                                         |
 | calibre                    |    webserver    |    webserver    | 8081  |   TCP    |                                         |
 | traccar                    |      main       |      main       | 8082  |   TCP    |                                         |
-| calibre                    |      main       |      main       | 8083  |   TCP    |                                         |
+| calibre-web                |      main       |      main       | 8083  |   TCP    |                                         |
+| calibre                    |      main       |      main       | 8084  |   TCP    |                                         |
 | htpcmanager                |      main       |      main       | 8085  |   TCP    |                                         |
 | synclounge                 |      main       |      main       | 8088  |   TCP    |                                         |
 | mylar                      |      main       |      main       | 8090  |   TCP    |                                         |
@@ -223,7 +224,6 @@ These defaults can of course be changed, but as we guarantee "sane, working defa
 | static                     |      main       |      main       | 10077 |   TCP    |                                         |
 | twtxt                      |      main       |      main       | 10078 |   TCP    |                                         |
 | emby                       |      main       |      main       | 10079 |   TCP    |                                         |
-| calibre                    |      main       |      main       | 10080 |   TCP    |                                         |
 | davos                      |      main       |      main       | 10081 |   TCP    |                                         |
 | fireflyiii                 |      main       |      main       | 10082 |   TCP    |                                         |
 | fossil                     |      main       |      main       | 10083 |   TCP    |                                         |


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Fixes # <!--(issue)-->

It did not like the `10080` port, browser was giving `ERR_USAFE_PORT`, lowered to 8084 (as this was free) and now working fine.

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
