### PR TITLE
feat(common): add TTY, STDIN and IPFamily support

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.11.0
+version: 8.12.0

--- a/charts/library/common/templates/classes/_service.tpl
+++ b/charts/library/common/templates/classes/_service.tpl
@@ -72,6 +72,13 @@ spec:
   {{- if $values.publishNotReadyAddresses }}
   publishNotReadyAddresses: {{ $values.publishNotReadyAddresses }}
   {{- end }}
+  {{- if $values.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ $values.ipFamilyPolicy }}
+  {{- end }}
+  {{- with $values.ipFamilies }}
+  ipFamilies:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
   ports:
   {{- range $name, $port := $values.ports }}
   {{- if $port.enabled }}

--- a/charts/library/common/templates/lib/controller/_container.tpl
+++ b/charts/library/common/templates/lib/controller/_container.tpl
@@ -19,6 +19,8 @@
     {{ toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
+  tty: {{ .Values.tty }}
+  stdin: {{ .Values.stdin }}
   {{- with .Values.securityContext }}
   securityContext:
     {{- toYaml . | nindent 4 }}

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -145,6 +145,12 @@ podLabelsList: []
 # -- Set labels on the pod
 podLabels: {}
 
+# -- Determines whether containers in a pod runs with TTY enabled.
+tty: false
+
+# -- Determines whether containers in a pod runs with stdin enabled.
+stdin: false
+
 # -- Add a Horizontal Pod Autoscaler
 # @default -- <disabled>
 autoscaling:

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -454,6 +454,12 @@ service:
     # @default -- See below
     portsList: []
 
+    # -- Specify the ip policy. Options: SingleStack, PreferDualStack, RequireDualStack
+    ipFamilyPolicy: SingleStack
+
+    # -- The ip families that should be used. Options: IPv4, IPv6
+    ipFamilies: [ ]
+
     # -- Configure the Service port information here.
     # Additional ports can be added by adding a dictionary key similar to the 'http' service.
     # @default -- See below

--- a/templates/questions/containerConfig.yaml
+++ b/templates/questions/containerConfig.yaml
@@ -27,6 +27,20 @@
       default: false
       show_subquestions_if: true
       subquestions:
+        - variable: tty
+          label: "Enable TTY"
+          description: "Determines whether containers in a pod runs with TTY enabled. By default pod has it disabled."
+          group: "Workload Details"
+          schema:
+            type: boolean
+            default: false
+        - variable: stdin
+          label: "Enable STDIN"
+          description: "Determines whether containers in a pod runs with stdin enabled. By default pod has it disabled."
+          group: "Workload Details"
+          schema:
+            type: boolean
+            default: false
         - variable: termination
           group: "Container Configuration"
           label: "Termination settings"

--- a/templates/questions/serviceExpert.yaml
+++ b/templates/questions/serviceExpert.yaml
@@ -1,78 +1,78 @@
-  - variable: externalInterfaces
-    description: "Add External Interfaces"
-    label: "Add external Interfaces"
-    group: "Networking"
-    schema:
-      type: list
-      items:
-        - variable: interfaceConfiguration
-          description: "Interface Configuration"
-          label: "Interface Configuration"
+        - variable: externalInterfaces
+          description: "Add External Interfaces"
+          label: "Add external Interfaces"
+          group: "Networking"
           schema:
-            type: dict
-            $ref:
-              - "normalize/interfaceConfiguration"
-            attrs:
-              - variable: hostInterface
-                description: "Please specify host interface"
-                label: "Host Interface"
-                schema:
-                  type: string
-                  required: true
-                  $ref:
-                    - "definitions/interface"
-              - variable: ipam
-                description: "Define how IP Address will be managed"
-                label: "IP Address Management"
+            type: list
+            items:
+              - variable: interfaceConfiguration
+                description: "Interface Configuration"
+                label: "Interface Configuration"
                 schema:
                   type: dict
-                  required: true
+                  $ref:
+                    - "normalize/interfaceConfiguration"
                   attrs:
-                    - variable: type
-                      description: "Specify type for IPAM"
-                      label: "IPAM Type"
+                    - variable: hostInterface
+                      description: "Please specify host interface"
+                      label: "Host Interface"
                       schema:
                         type: string
                         required: true
-                        enum:
-                          - value: "dhcp"
-                            description: "Use DHCP"
-                          - value: "static"
-                            description: "Use static IP"
-                        show_subquestions_if: "static"
-                        subquestions:
-                          - variable: staticIPConfigurations
-                            label: "Static IP Addresses"
+                        $ref:
+                          - "definitions/interface"
+                    - variable: ipam
+                      description: "Define how IP Address will be managed"
+                      label: "IP Address Management"
+                      schema:
+                        type: dict
+                        required: true
+                        attrs:
+                          - variable: type
+                            description: "Specify type for IPAM"
+                            label: "IPAM Type"
                             schema:
-                              type: list
-                              items:
-                                - variable: staticIP
-                                  label: "Static IP"
+                              type: string
+                              required: true
+                              enum:
+                                - value: "dhcp"
+                                  description: "Use DHCP"
+                                - value: "static"
+                                  description: "Use static IP"
+                              show_subquestions_if: "static"
+                              subquestions:
+                                - variable: staticIPConfigurations
+                                  label: "Static IP Addresses"
                                   schema:
-                                    type: ipaddr
-                                    cidr: true
-                          - variable: staticRoutes
-                            label: "Static Routes"
-                            schema:
-                              type: list
-                              items:
-                                - variable: staticRouteConfiguration
-                                  label: "Static Route Configuration"
-                                  schema:
-                                    type: dict
-                                    attrs:
-                                      - variable: destination
-                                        label: "Destination"
+                                    type: list
+                                    items:
+                                      - variable: staticIP
+                                        label: "Static IP"
                                         schema:
                                           type: ipaddr
                                           cidr: true
-                                          required: true
-                                      - variable: gateway
-                                        label: "Gateway"
+                                - variable: staticRoutes
+                                  label: "Static Routes"
+                                  schema:
+                                    type: list
+                                    items:
+                                      - variable: staticRouteConfiguration
+                                        label: "Static Route Configuration"
                                         schema:
-                                          type: ipaddr
-                                          cidr: false
-                                          required: true
+                                          type: dict
+                                          attrs:
+                                            - variable: destination
+                                              label: "Destination"
+                                              schema:
+                                                type: ipaddr
+                                                cidr: true
+                                                required: true
+                                            - variable: gateway
+                                              label: "Gateway"
+                                              schema:
+                                                type: ipaddr
+                                                cidr: false
+                                                required: true
 
         - variable: dnsPolicy
           group: "Networking and Services"

--- a/templates/questions/serviceSelector.yaml
+++ b/templates/questions/serviceSelector.yaml
@@ -38,6 +38,32 @@
                       label: "External IP"
                       schema:
                         type: string
+              - variable: ipFamilyPolicy
+                label: "IP Family Policy"
+                description: "(Advanced) Specify the ip policy"
+                schema:
+                  show_if: [["type", "!=", "Simple"]]
+                  type: string
+                  default: "SingleStack"
+                  enum:
+                    - value: "SingleStack"
+                      description: "SingleStack"
+                    - value: "PreferDualStack"
+                      description: "PreferDualStack"
+                    - value: "RequireDualStack"
+                      description: "RequireDualStack"
+              - variable: ipFamilies
+                label: "(advanced) IP families"
+                description: "(advanced) The ip families that should be used"
+                schema:
+                  show_if: [["type", "!=", "Simple"]]
+                  type: list
+                  default: []
+                  items:
+                    - variable: ipFamily
+                      label: "IP family"
+                      schema:
+                        type: string
               - variable: ports
                 label: "Service's Port(s) Configuration"
                 schema:


### PR DESCRIPTION
**Description**
Official has added support for TTY and STDIN and it's rather trivial to follow them.
K8S-at-home, on the otherhand, added support for IPFamilies and the community has been requesting more solid IPv6 support. This is also relatively trivial to add.

Also fixes a mistake in the GUI for external interfaces

**Type of change**

- [x] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
