### PR TITLE
feat(amd-gpu-plugin): Add AMD gpu plugin as app

### DIFF
--- a/.github/ct-install.yaml
+++ b/.github/ct-install.yaml
@@ -12,4 +12,5 @@ excluded-charts:
 chart-repos:
 - truecharts=https://truecharts.org
 - bitnami=https://charts.bitnami.com/bitnami
+- amd-gpu-helm=https://radeonopencompute.github.io/k8s-device-plugin/
 SkipExisting: true

--- a/.github/ct-lint.yaml
+++ b/.github/ct-lint.yaml
@@ -5,4 +5,5 @@ chart-yaml-schema: .github/chart_schema.yaml
 chart-repos:
 - truecharts=https://truecharts.org
 - bitnami=https://charts.bitnami.com/bitnami
+- amd-gpu-helm=https://radeonopencompute.github.io/k8s-device-plugin/
 SkipExisting: true

--- a/.github/workflows/apps.test.yaml
+++ b/.github/workflows/apps.test.yaml
@@ -117,6 +117,7 @@ jobs:
           helm repo add metallb https://metallb.github.io/metallb
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add prometheus https://prometheus-community.github.io/helm-charts
+          helm repo add amd-gpu-helm https://radeonopencompute.github.io/k8s-device-plugin/
           helm repo update
 
       - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # renovate: tag=v2

--- a/.github/workflows/common.test.yaml
+++ b/.github/workflows/common.test.yaml
@@ -41,6 +41,7 @@ jobs:
           helm repo add metallb https://metallb.github.io/metallb
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add prometheus https://prometheus-community.github.io/helm-charts
+          helm repo add amd-gpu-helm https://radeonopencompute.github.io/k8s-device-plugin/
           helm repo update
 
       - name: Run chart-testing (lint)
@@ -81,6 +82,7 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add metallb https://metallb.github.io/metallb
           helm repo add prometheus https://prometheus-community.github.io/helm-charts
+          helm repo add amd-gpu-helm https://radeonopencompute.github.io/k8s-device-plugin/
           helm repo update
 
       - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # renovate: tag=v2

--- a/charts/core/amd-gpu-plugin/.helmignore
+++ b/charts/core/amd-gpu-plugin/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/core/amd-gpu-plugin/Chart.yaml
+++ b/charts/core/amd-gpu-plugin/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+appVersion: "upstream"
+deprecated: false
+description: A kubernetes plugin to add AMD GPU's to Pods
+home: https://github.com/truecharts/apps/tree/master/charts/stable/amd-gpu-plugin
+icon: https://truecharts.org/_static/img/appicons/amd-gpu-plugin.png
+keywords:
+- amd
+- gpu
+- plugin
+dependencies:
+- name: amd-gpu
+  repository: https://radeonopencompute.github.io/k8s-device-plugin/
+  version: 0.2.0
+kubeVersion: '>=1.16.0-0'
+maintainers:
+- email: info@truecharts.org
+  name: TrueCharts
+  url: https://truecharts.org
+name: amd-gpu-plugin
+sources:
+  - https://github.com/metallb/metallb
+  - https://metallb.universe.tf
+type: application
+version: 0.0.1
+annotations:
+  truecharts.org/catagories: |
+    - core
+  truecharts.org/SCALE-support: "true"
+  truecharts.org/grade: U

--- a/charts/core/amd-gpu-plugin/questions.yaml
+++ b/charts/core/amd-gpu-plugin/questions.yaml
@@ -1,0 +1,30 @@
+# Include{groups}
+questions:
+# Include{global}
+
+  - variable: amd-gpu
+    group: "App Configuration"
+    label: ""
+    schema:
+      type: dict
+      attrs:
+        - variable: nfd
+          label: "nfd"
+          schema:
+            type: dict
+            attrs:
+              - variable: enabled
+                label: "enabled"
+                schema:
+                  type: boolean
+                  default: false
+        - variable: labeller
+          label: "labeller"
+          schema:
+            type: dict
+            attrs:
+              - variable: enabled
+                label: "enabled"
+                schema:
+                  type: boolean
+                  default: false

--- a/charts/core/amd-gpu-plugin/values.yaml
+++ b/charts/core/amd-gpu-plugin/values.yaml
@@ -1,0 +1,15 @@
+image:
+  repository: placeholder
+  # defaults to appVersion
+  tag: upstream
+  pullPolicy: IfNotPresent
+
+metallb:
+  # configInline specifies MetalLB's configuration directly, in yaml
+  # format. When configInline is used, Helm manages MetalLB's
+  # configuration ConfigMap as part of the release, and
+  # existingConfigMap is ignored.
+  #
+  # Refer to https://metallb.universe.tf/configuration/ for
+  # available options.
+  configInline: {}

--- a/charts/core/amd-gpu-plugin/values.yaml
+++ b/charts/core/amd-gpu-plugin/values.yaml
@@ -3,13 +3,3 @@ image:
   # defaults to appVersion
   tag: upstream
   pullPolicy: IfNotPresent
-
-metallb:
-  # configInline specifies MetalLB's configuration directly, in yaml
-  # format. When configInline is used, Helm manages MetalLB's
-  # configuration ConfigMap as part of the release, and
-  # existingConfigMap is ignored.
-  #
-  # Refer to https://metallb.universe.tf/configuration/ for
-  # available options.
-  configInline: {}


### PR DESCRIPTION
**Description**
As indicated on the TrueNAS Forum, adding the AMD device plugin is enough to allow for GUI selection of AMD GPU's.
This adds the device plugin as an App, so should allow for the selection.

**Type of change**

- [X] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
