### PR TITLE
Avoid port 10080

### DIFF
--- a/charts/incubator/trilium-notes/Chart.yaml
+++ b/charts/incubator/trilium-notes/Chart.yaml
@@ -23,7 +23,7 @@ sources:
 - https://hub.docker.com/r/zadam/trilium
 - https://github.com/zadam/trilium
 type: application
-version: 0.0.1
+version: 0.0.2
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/incubator/trilium-notes/questions.yaml
+++ b/charts/incubator/trilium-notes/questions.yaml
@@ -108,7 +108,7 @@ questions:
                             description: "This port exposes the container port on the service"
                             schema:
                               type: int
-                              default: 10080
+                              default: 10086
                               required: true
                           - variable: advanced
                             label: "Show Advanced settings"

--- a/charts/incubator/trilium-notes/values.yaml
+++ b/charts/incubator/trilium-notes/values.yaml
@@ -9,7 +9,7 @@ service:
       main:
         protocol: HTTP
         targetPort: 8080
-        port: 10080
+        port: 10086
 
 env:
   TRILIUM_DATA_DIR: "/trilium-data"

--- a/docs/manual/default-ports.md
+++ b/docs/manual/default-ports.md
@@ -227,7 +227,6 @@ These defaults can of course be changed, but as we guarantee "sane, working defa
 | static                     |      main       |      main       | 10077 |   TCP    |                                         |
 | twtxt                      |      main       |      main       | 10078 |   TCP    |                                         |
 | emby                       |      main       |      main       | 10079 |   TCP    |                                         |
-| _Do-not-use-for-HTTP_      |      main       |      main       | 10080 |    -     | HTTP access blocked by web browsers.    |
 | davos                      |      main       |      main       | 10081 |   TCP    |                                         |
 | fireflyiii                 |      main       |      main       | 10082 |   TCP    |                                         |
 | fossil                     |      main       |      main       | 10083 |   TCP    |                                         |
@@ -365,6 +364,12 @@ These defaults can of course be changed, but as we guarantee "sane, working defa
 | ssh     |  22  |   TCP    |      |
 | webui   |  80  |   HTTP   |      |
 | webui   | 443  |  HTTPS   |      |
+
+## Ports above 10000 blocked in major web browsers
+
+| Port  |
+| :---: |
+| 10080 |
 
 ##### Note: TCP and UDP ports that are the same in some Apps, are not by mistake.
 

--- a/docs/manual/default-ports.md
+++ b/docs/manual/default-ports.md
@@ -365,12 +365,90 @@ These defaults can of course be changed, but as we guarantee "sane, working defa
 | webui   |  80  |   HTTP   |      |
 | webui   | 443  |  HTTPS   |      |
 
-## Ports above 10000 blocked in major web browsers
+## Ports that are blocked in major web browsers
 
-| Port  |
-| :---: |
-| 10080 |
-
+| Port  | Used by (example) |
+| :---: | :---: |
+| 1 | tcpmux | 
+| 7 | echo | 
+| 9 | discard | 
+| 11 | systat | 
+| 13 | daytime | 
+| 15 | netstat | 
+| 17 | qotd | 
+| 19 | chargen | 
+| 20 | ftp data | 
+| 21 | ftp access | 
+| 22 | ssh | 
+| 23 | telnet | 
+| 25 | smtp | 
+| 37 | time | 
+| 42 | name | 
+| 43 | nicname | 
+| 53 | domain | 
+| 69 | tftp | 
+| 77 | priv-rjs | 
+| 79 | finger | 
+| 87 | ttylink | 
+| 95 | supdup | 
+| 101 | hostriame | 
+| 102 | iso-tsap | 
+| 103 | gppitnp | 
+| 104 | acr-nema | 
+| 109 | pop2 | 
+| 110 | pop3 | 
+| 111 | sunrpc | 
+| 113 | auth | 
+| 115 | sftp | 
+| 117 | uucp-path | 
+| 119 | nntp | 
+| 123 | NTP | 
+| 135 | loc-srv /epmap | 
+| 137 | netbios | 
+| 139 | netbios | 
+| 143 | imap2 | 
+| 161 | snmp | 
+| 179 | BGP | 
+| 389 | ldap | 
+| 427 | SLP (Also used by Apple Filing Protocol) | 
+| 465 | smtp+ssl | 
+| 512 | print / exec | 
+| 513 | login | 
+| 514 | shell | 
+| 515 | printer | 
+| 526 | tempo | 
+| 530 | courier | 
+| 531 | chat | 
+| 532 | netnews | 
+| 540 | uucp | 
+| 548 | AFP (Apple Filing Protocol) | 
+| 554 | rtsp | 
+| 556 | remotefs | 
+| 563 | nntp+ssl | 
+| 587 | smtp (rfc6409) | 
+| 601 | syslog-conn (rfc3195) | 
+| 636 | ldap+ssl | 
+| 989 | ftps-data | 
+| 990 | ftps | 
+| 993 | ldap+ssl | 
+| 995 | pop3+ssl | 
+| 1719 | h323gatestat | 
+| 1720 | h323hostcall | 
+| 1723 | pptp | 
+| 2049 | nfs | 
+| 3659 | apple-sasl / PasswordServer | 
+| 4045 | lockd | 
+| 5060 | sip | 
+| 5061 | sips | 
+| 6000 | X11 | 
+| 6566 | sane-port | 
+| 6665 | Alternate IRC [Apple addition] | 
+| 6666 | Alternate IRC [Apple addition] | 
+| 6667 | Standard IRC [Apple addition] | 
+| 6668 | Alternate IRC [Apple addition] | 
+| 6669 | Alternate IRC [Apple addition] | 
+| 6697 | IRC + TLS | 
+| 10080 | Amanda |
 ##### Note: TCP and UDP ports that are the same in some Apps, are not by mistake.
 
 ##### If you notice a port conflict, please notify us so we can resolve it (when possible).

--- a/docs/manual/default-ports.md
+++ b/docs/manual/default-ports.md
@@ -227,12 +227,13 @@ These defaults can of course be changed, but as we guarantee "sane, working defa
 | static                     |      main       |      main       | 10077 |   TCP    |                                         |
 | twtxt                      |      main       |      main       | 10078 |   TCP    |                                         |
 | emby                       |      main       |      main       | 10079 |   TCP    |                                         |
-| trilium-notes              |      main       |      main       | 10080 |   HTTP   |                                         |
+| _Do-not-use-for-HTTP_      |      main       |      main       | 10080 |    -     | HTTP access blocked by web browsers.    |
 | davos                      |      main       |      main       | 10081 |   TCP    |                                         |
 | fireflyiii                 |      main       |      main       | 10082 |   TCP    |                                         |
 | fossil                     |      main       |      main       | 10083 |   TCP    |                                         |
 | gotify                     |      main       |      main       | 10084 |   TCP    |                                         |
 | komga                      |      main       |      main       | 10085 |   TCP    |                                         |
+| trilium-notes              |      main       |      main       | 10086 |   HTTP   |                                         |
 | owncast                    |      main       |      main       | 10088 |   TCP    |                                         |
 | openkm                     |      main       |      main       | 10090 |   TCP    |                                         |
 | miniflux                   |      main       |      main       | 10091 |   TCP    |                                         |


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Port 10080 is blocked by all major web browsers, including Firefox, Chrome, and Edge.

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
For http access to port 10080, Chromium based browsers say `ERR_UNSAFE_PORT` and Firefox says `This address is restricted`.
This could lead to confused users and bug reports. To test, simply try accessing any real or fake IP address with http:// and port 10080 on a major web browser.

**Notes:**
<!-- Please enter any other relevant information here -->
I considered adding a complete list of ports blocked by major web browsers in a table format at the bottom, but that list can get long and require maintenance. Port 10080 is the only port above 10000 that seems to be blocked by major web browsers.
When using ingress, this is not an issue, but it's often preferable to test and set up an app without ingress first.

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
