### PR TITLE
fix(omada-controller): Add missing protocol for omada-udp3 service port

### DIFF
--- a/charts/incubator/omada-controller/values.yaml
+++ b/charts/incubator/omada-controller/values.yaml
@@ -62,6 +62,7 @@ service:
         targetPort: 29811
       omada-udp3:
         enabled: true
+        protocol: UDP
         port: 29812
         targetPort: 29812
       omada-udp4:


### PR DESCRIPTION
The Omada controller omada-udp3 service port spec was missing the protocol leading to failures to deploy.
<!--

-->
Fixes # <!--(issue)-->

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Tested deployment.
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
