### PR TITLE
fix(n8n): Fix permissions and add healthcheck path

### DIFF
--- a/charts/incubator/n8n/Chart.yaml
+++ b/charts/incubator/n8n/Chart.yaml
@@ -28,7 +28,7 @@ sources:
 - https://docs.n8n.io/
 - https://github.com/n8n-io/n8n
 - https://hub.docker.com/r/n8nio/n8n
-version: 0.0.3
+version: 0.0.4
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/incubator/n8n/questions.yaml
+++ b/charts/incubator/n8n/questions.yaml
@@ -561,49 +561,6 @@ questions:
       additional_attrs: true
       type: dict
       attrs:
-        - variable: config
-          label: "App Config Storage"
-          description: "Stores the Application Config."
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-              - variable: type
-                label: "Type of Storage"
-                description: "Sets the persistence type, Anything other than PVC could break rollback!"
-                schema:
-                  type: string
-                  default: "simplePVC"
-                  enum:
-                    - value: "simplePVC"
-                      description: "PVC (simple)"
-                    - value: "simpleHP"
-                      description: "HostPath (simple)"
-                    - value: "emptyDir"
-                      description: "emptyDir"
-                    - value: "pvc"
-                      description: "pvc"
-                    - value: "hostPath"
-                      description: "hostPath"
-# Include{persistenceBasic}
-              - variable: hostPath
-                label: "hostPath"
-                description: "Path inside the container the storage is mounted"
-                schema:
-                  show_if: [["type", "=", "hostPath"]]
-                  type: hostpath
-              - variable: medium
-                label: "EmptyDir Medium"
-                schema:
-                  show_if: [["type", "=", "emptyDir"]]
-                  type: string
-                  default: ""
-                  enum:
-                    - value: ""
-                      description: "Default"
-                    - value: "Memory"
-                      description: "Memory"
-# Include{persistenceAdvanced}
         - variable: data
           label: "App Data Storage"
           description: "Stores the Application Data."

--- a/charts/incubator/n8n/questions.yaml
+++ b/charts/incubator/n8n/questions.yaml
@@ -683,13 +683,13 @@ questions:
           description: The groupID this App of the user running the application"
           schema:
             type: int
-            default: 0
+            default: 568
         - variable: fsGroup
           label: "fsGroup"
           description: "The group that should own ALL storage."
           schema:
             type: int
-            default: 568
+            default: 1000
 # Include{podSecurityContextAdvanced}
 
 # Include{resources}

--- a/charts/incubator/n8n/values.yaml
+++ b/charts/incubator/n8n/values.yaml
@@ -108,7 +108,7 @@ service:
         targetPort: 5678
 
 persistence:
-  config:
+  data:
     enabled: true
     mountPath: "/home/node/.n8n"
 

--- a/charts/incubator/n8n/values.yaml
+++ b/charts/incubator/n8n/values.yaml
@@ -19,7 +19,6 @@ env:
   DB_POSTGRESDB_DATABASE: "{{ .Values.postgresql.postgresqlDatabase }}"
   DB_POSTGRESDB_PORT: 5432
   QUEUE_BULL_REDIS_PORT: 6379
-  N8N_USER_FOLDER: "/data"
 
 credentials: {}
   # CREDENTIALS_OVERWRITE_DATA: ""
@@ -112,9 +111,6 @@ persistence:
   config:
     enabled: true
     mountPath: "/home/node/.n8n"
-  data:
-    enabled: true
-    mountPath: "/data"
 
 # Enabled redis
 redis:

--- a/charts/incubator/n8n/values.yaml
+++ b/charts/incubator/n8n/values.yaml
@@ -21,6 +21,14 @@ env:
   QUEUE_BULL_REDIS_PORT: 6379
   N8N_USER_FOLDER: "/data"
 
+probes:
+  liveness:
+    path: "/healthz"
+  readiness:
+    path: "/healthz"
+  startup:
+    path: "/healthz"
+
 credentials: {}
   # CREDENTIALS_OVERWRITE_DATA: ""
   # CREDENTIALS_OVERWRITE_ENDPOINT: ""

--- a/charts/incubator/n8n/values.yaml
+++ b/charts/incubator/n8n/values.yaml
@@ -9,7 +9,7 @@ securityContext:
 
 podSecurityContext:
   runAsUser: 0
-  runAsGroup: 0
+  fsGroup: 1000
 
 env:
   TZ: UTC
@@ -19,6 +19,7 @@ env:
   DB_POSTGRESDB_DATABASE: "{{ .Values.postgresql.postgresqlDatabase }}"
   DB_POSTGRESDB_PORT: 5432
   QUEUE_BULL_REDIS_PORT: 6379
+  N8N_USER_FOLDER: "/data"
 
 credentials: {}
   # CREDENTIALS_OVERWRITE_DATA: ""
@@ -110,7 +111,7 @@ service:
 persistence:
   data:
     enabled: true
-    mountPath: "/home/node/.n8n"
+    mountPath: "/data"
 
 # Enabled redis
 redis:

--- a/charts/incubator/unmanic/Chart.yaml
+++ b/charts/incubator/unmanic/Chart.yaml
@@ -18,7 +18,7 @@ name: unmanic
 sources:
 - https://github.com/Unmanic/unmanic
 - https://hub.docker.com/r/josh5/unmanic
-version: 0.0.1
+version: 0.0.2
 annotations:
   truecharts.org/catagories: |
     - media


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Fixes # <!--(issue)-->

Removed `/home/node/.n8n` persistence as the `/data` is used correctly now, and it actually stores the data there.

It needs to have `runAsUser: 0`

`runAsGroup` can be ANYTHING. (It starts and can create files through GUI, without errors with any user I tried)
`fsGroup` HAS to be `1000` (node user)

No idea while tests was passing tests here on CI (with the initial perms), but wouldn't deploy on SCALE (with pvc).
While it would deploy fine with `emptyDir` 

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
