### PR TITLE
feat(common): force `NVIDIA_VISIBLE_DEVICES: "void"` when no GPU is assigned

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.14.2
+version: 8.14.3

--- a/charts/library/common/templates/lib/controller/_container.tpl
+++ b/charts/library/common/templates/lib/controller/_container.tpl
@@ -56,6 +56,10 @@
     - name: S6_READ_ONLY_ROOT
       value: "1"
    {{- end }}
+   {{- if not ( .Values.scaleGPU ) }}
+    - name: NVIDIA_VISIBLE_DEVICES
+      value: "void"
+   {{- end }}
    {{- range $key, $value := .Values.envTpl }}
     - name: {{ $key }}
       value: {{ tpl $value $ | quote }}

--- a/tests/library/common/container_spec.rb
+++ b/tests/library/common/container_spec.rb
@@ -124,8 +124,8 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:envList][0][:name].to_s, mainContainer["env"][4]["name"])
-        assert_equal(values[:envList][0][:value].to_s, mainContainer["env"][4]["value"])
+        assert_equal(values[:envList][0][:name].to_s, mainContainer["env"][5]["name"])
+        assert_equal(values[:envList][0][:value].to_s, mainContainer["env"][5]["value"])
       end
 
       it 'set both static "k/v pair style" and static "k/valueFrom style" environment variables' do
@@ -145,10 +145,10 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][4]["name"])
-        assert_equal(values[:env].values[0].to_s, mainContainer["env"][4]["value"])
-        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][5]["name"])
-        assert_equal(values[:env].values[1][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][5]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][5]["name"])
+        assert_equal(values[:env].values[0].to_s, mainContainer["env"][5]["value"])
+        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][6]["name"])
+        assert_equal(values[:env].values[1][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][6]["valueFrom"]["fieldRef"]["fieldPath"])
       end
 
       it 'set static "k/explicitValueFrom pair style" environment variables' do
@@ -167,8 +167,8 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][4]["name"])
-        assert_equal(values[:env].values[0][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][4]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][5]["name"])
+        assert_equal(values[:env].values[0][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][5]["valueFrom"]["fieldRef"]["fieldPath"])
       end
 
       it 'set static "k/implicitValueFrom pair style" environment variables' do
@@ -185,8 +185,8 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][4]["name"])
-        assert_equal(values[:env].values[0][:fieldRef][:fieldPath], mainContainer["env"][4]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][5]["name"])
+        assert_equal(values[:env].values[0][:fieldRef][:fieldPath], mainContainer["env"][5]["valueFrom"]["fieldRef"]["fieldPath"])
       end
 
       it 'set both static "k/v pair style" and templated "k/v pair style" environment variables' do
@@ -200,10 +200,10 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][4]["name"])
-        assert_equal("common-test-admin", mainContainer["env"][4]["value"])
-        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][5]["name"])
-        assert_equal(values[:env].values[1].to_s, mainContainer["env"][5]["value"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][5]["name"])
+        assert_equal("common-test-admin", mainContainer["env"][5]["value"])
+        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][6]["name"])
+        assert_equal(values[:env].values[1].to_s, mainContainer["env"][6]["value"])
       end
 
       it 'set templated "k/v pair style" environment variables' do
@@ -216,8 +216,8 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][4]["name"])
-        assert_equal("common-test-admin", mainContainer["env"][4]["value"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][5]["name"])
+        assert_equal("common-test-admin", mainContainer["env"][5]["value"])
       end
 
       it 'set static "k/v pair style", templated "k/v pair style", static "k/explicitValueFrom pair style", and static "k/implicitValueFrom pair style" environment variables' do
@@ -243,14 +243,14 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][4]["name"])
-        assert_equal("common-test-admin", mainContainer["env"][4]["value"])
-        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][5]["name"])
-        assert_equal(values[:env].values[1].to_s, mainContainer["env"][5]["value"])
-        assert_equal(values[:env].keys[2].to_s, mainContainer["env"][6]["name"])
-        assert_equal(values[:env].values[2][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][6]["valueFrom"]["fieldRef"]["fieldPath"])
-        assert_equal(values[:env].keys[3].to_s, mainContainer["env"][7]["name"])
-        assert_equal(values[:env].values[3][:fieldRef][:fieldPath], mainContainer["env"][7]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][5]["name"])
+        assert_equal("common-test-admin", mainContainer["env"][5]["value"])
+        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][6]["name"])
+        assert_equal(values[:env].values[1].to_s, mainContainer["env"][6]["value"])
+        assert_equal(values[:env].keys[2].to_s, mainContainer["env"][7]["name"])
+        assert_equal(values[:env].values[2][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][7]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:env].keys[3].to_s, mainContainer["env"][8]["name"])
+        assert_equal(values[:env].values[3][:fieldRef][:fieldPath], mainContainer["env"][8]["valueFrom"]["fieldRef"]["fieldPath"])
       end
 
       it 'set "static" secret variables' do

--- a/tests/library/common/container_spec.rb
+++ b/tests/library/common/container_spec.rb
@@ -101,14 +101,14 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][4]["name"])
-        assert_equal(values[:env].values[0].to_s, mainContainer["env"][4]["value"])
-        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][5]["name"])
-        assert_equal(values[:env].values[1].to_s, mainContainer["env"][5]["value"])
-        assert_equal(values[:env].keys[2].to_s, mainContainer["env"][6]["name"])
-        assert_equal(values[:env].values[2].to_s, mainContainer["env"][6]["value"])
-        assert_equal(values[:env].keys[3].to_s, mainContainer["env"][7]["name"])
-        assert_equal(values[:env].values[3].to_s, mainContainer["env"][7]["value"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][5]["name"])
+        assert_equal(values[:env].values[0].to_s, mainContainer["env"][5]["value"])
+        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][6]["name"])
+        assert_equal(values[:env].values[1].to_s, mainContainer["env"][6]["value"])
+        assert_equal(values[:env].keys[2].to_s, mainContainer["env"][7]["name"])
+        assert_equal(values[:env].values[2].to_s, mainContainer["env"][7]["value"])
+        assert_equal(values[:env].keys[3].to_s, mainContainer["env"][8]["name"])
+        assert_equal(values[:env].values[3].to_s, mainContainer["env"][8]["value"])
       end
 
       it 'set list of static "kubernetes style" environment variables' do


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Fixes # <!--(issue)-->
This applies `NVIDIA_VISIBLE_DEVICES: "void"` when no GPU is assigned, as we might encounter more apps failing to start on cases like the one mentioned in #1817.

AFAIK it's not harmful to apply the above var when no GPU is assigned.

**Type of change**

- [x] Feature/App addition
- [ ] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [ ] I increased versions for any altered app according to semantic versioning
