### PR TITLE
fix(minio): Fix services and add ingress option for both services

### DIFF
--- a/charts/stable/minio/Chart.yaml
+++ b/charts/stable/minio/Chart.yaml
@@ -19,7 +19,7 @@ maintainers:
 name: minio
 sources:
 - https://github.com/minio/minio
-version: 1.0.28
+version: 1.1.0
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/minio/questions.yaml
+++ b/charts/stable/minio/questions.yaml
@@ -6,7 +6,7 @@ portals:
     host:
       - "$kubernetes-resource_configmap_portal_host"
     ports:
-      - "$variable-service.console.ports.console.port"
+      - "$kubernetes-resource_configmap_portal_port"
 questions:
   - variable: portal
     group: "Container Image"
@@ -143,62 +143,6 @@ questions:
                             description: "This port exposes the container port on the service"
                             schema:
                               type: int
-                              default: 10106
-                              required: true
-                          - variable: advanced
-                            label: "Show Advanced settings"
-                            schema:
-                              type: boolean
-                              default: false
-                              show_subquestions_if: true
-                              subquestions:
-                                - variable: protocol
-                                  label: "Port Type"
-                                  schema:
-                                    type: string
-                                    default: "HTTP"
-                                    enum:
-                                      - value: HTTP
-                                        description: "HTTP"
-                                      - value: "HTTPS"
-                                        description: "HTTPS"
-                                      - value: TCP
-                                        description: "TCP"
-                                      - value: "UDP"
-                                        description: "UDP"
-                                - variable: nodePort
-                                  label: "Node Port (Optional)"
-                                  description: "This port gets exposed to the node. Only considered when service type is NodePort, Simple or LoadBalancer"
-                                  schema:
-                                    type: int
-                                    min: 9000
-                                    max: 65535
-                                - variable: targetPort
-                                  label: "Target Port"
-                                  description: "The internal(!) port on the container the Application runs on"
-                                  schema:
-                                    type: int
-                                    default: 10106
-
-        - variable: console
-          label: "Console Service"
-          description: "The Primary service on which the healthcheck runs, often the webUI"
-          schema:
-            additional_attrs: true
-            type: dict
-            attrs:
-# Include{serviceSelector}
-                    - variable: console
-                      label: "Console Service Port Configuration"
-                      schema:
-                        additional_attrs: true
-                        type: dict
-                        attrs:
-                          - variable: port
-                            label: "Port"
-                            description: "This port exposes the container port on the service"
-                            schema:
-                              type: int
                               default: 10107
                               required: true
                           - variable: advanced
@@ -235,6 +179,62 @@ questions:
                                   schema:
                                     type: int
                                     default: 10107
+
+        - variable: api
+          label: "API Service"
+          description: "The Primary service on which the healthcheck runs, often the webUI"
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{serviceSelector}
+                    - variable: api
+                      label: "API Service Port Configuration"
+                      schema:
+                        additional_attrs: true
+                        type: dict
+                        attrs:
+                          - variable: port
+                            label: "Port"
+                            description: "This port exposes the container port on the service"
+                            schema:
+                              type: int
+                              default: 10106
+                              required: true
+                          - variable: advanced
+                            label: "Show Advanced settings"
+                            schema:
+                              type: boolean
+                              default: false
+                              show_subquestions_if: true
+                              subquestions:
+                                - variable: protocol
+                                  label: "Port Type"
+                                  schema:
+                                    type: string
+                                    default: "HTTP"
+                                    enum:
+                                      - value: HTTP
+                                        description: "HTTP"
+                                      - value: "HTTPS"
+                                        description: "HTTPS"
+                                      - value: TCP
+                                        description: "TCP"
+                                      - value: "UDP"
+                                        description: "UDP"
+                                - variable: nodePort
+                                  label: "Node Port (Optional)"
+                                  description: "This port gets exposed to the node. Only considered when service type is NodePort, Simple or LoadBalancer"
+                                  schema:
+                                    type: int
+                                    min: 9000
+                                    max: 65535
+                                - variable: targetPort
+                                  label: "Target Port"
+                                  description: "The internal(!) port on the container the Application runs on"
+                                  schema:
+                                    type: int
+                                    default: 10106
 
   - variable: serviceexpert
     group: "Networking and Services"
@@ -329,7 +329,7 @@ questions:
 
 # Include{ingressExpert}
 
-        - variable: console
+        - variable: api
           label: "Console Ingress"
           schema:
             additional_attrs: true

--- a/charts/stable/minio/questions.yaml
+++ b/charts/stable/minio/questions.yaml
@@ -329,6 +329,20 @@ questions:
 
 # Include{ingressExpert}
 
+        - variable: console
+          label: "Console Ingress"
+          schema:
+            additional_attrs: true
+            type: dict
+            attrs:
+# Include{ingressDefault}
+
+# Include{ingressTLS}
+
+# Include{ingressTraefik}
+
+# Include{ingressExpert}
+
 # Include{ingressList}
 
   - variable: advancedSecurity

--- a/charts/stable/minio/questions.yaml
+++ b/charts/stable/minio/questions.yaml
@@ -178,7 +178,7 @@ questions:
                                   description: "The internal(!) port on the container the Application runs on"
                                   schema:
                                     type: int
-                                    default: 9000
+                                    default: 10106
 
         - variable: console
           label: "Console Service"
@@ -234,7 +234,7 @@ questions:
                                   description: "The internal(!) port on the container the Application runs on"
                                   schema:
                                     type: int
-                                    default: 9001
+                                    default: 10107
 
   - variable: serviceexpert
     group: "Networking and Services"

--- a/charts/stable/minio/questions.yaml
+++ b/charts/stable/minio/questions.yaml
@@ -110,7 +110,7 @@ questions:
             default: ""
         - variable: MINIO_SERVER_URL
           label: "MINIO_SERVER_URL"
-          description: "Specify the URL hostname the MinIO Console should use for connecting to the MinIO Server. eg. https://minio.mydomain.com"
+          description: "Specify the URL hostname the MinIO Console should use for connecting to the MinIO Server. eg. https://minioserver.mydomain.com"
           schema:
             type: string
             default: ""

--- a/charts/stable/minio/questions.yaml
+++ b/charts/stable/minio/questions.yaml
@@ -6,7 +6,7 @@ portals:
     host:
       - "$kubernetes-resource_configmap_portal_host"
     ports:
-      - "$kubernetes-resource_configmap_portal_port"
+      - "$variable-service.console.ports.console.port"
 questions:
   - variable: portal
     group: "Container Image"
@@ -104,6 +104,13 @@ questions:
             required: true
         - variable: MINIO_BROWSER_REDIRECT_URL
           label: "MINIO_BROWSER_REDIRECT_URL"
+          description: "Specify the URL the MinIO Console provides as the redirect URL eg. https://minioconsole.mydomain.com"
+          schema:
+            type: string
+            default: ""
+        - variable: MINIO_SERVER_URL
+          label: "MINIO_SERVER_URL"
+          description: "Specify the URL hostname the MinIO Console should use for connecting to the MinIO Server. eg. https://minio.mydomain.com"
           schema:
             type: string
             default: ""

--- a/charts/stable/minio/values.yaml
+++ b/charts/stable/minio/values.yaml
@@ -9,11 +9,6 @@ secret:
   MINIO_ROOT_PASSWORD: "changeme"
 
 env:
-  # Set User "minio" to run the app with UID/GID from "runAs*"
-  MINIO_USERNAME: "minio"
-  MINIO_GROUPNAME: "minio"
-  MINIO_UID: "{{ .Values.podSecurityContext.runAsUser }}"
-  MINIO_GID: "{{ .Values.podSecurityContext.runAsGroup }}"
   MINIO_ROOT_USER: "minio"
   MINIO_BROWSER_REDIRECT_URL: ""
   MINIO_SERVER_URL: ""

--- a/charts/stable/minio/values.yaml
+++ b/charts/stable/minio/values.yaml
@@ -20,14 +20,14 @@ probes:
       httpGet:
         scheme: HTTP
         path: "/minio/health/live"
-        port: "{{ .Values.service.api.ports.api.targetPort }}"
+        port: 10106
   readiness:
     custom: true
     spec:
       httpGet:
         scheme: HTTP
         path: "/minio/health/ready"
-        port: "{{ .Values.service.api.ports.api.targetPort }}"
+        port: 10106
 
 service:
   main:

--- a/charts/stable/minio/values.yaml
+++ b/charts/stable/minio/values.yaml
@@ -1,24 +1,18 @@
 image:
-  # -- image repository
   repository: tccr.io/truecharts/minio
-  # -- image tag
   tag: latest@sha256:8129f69c85b84e13f085a1ce127f108cee0ea84a1f496e8065796c7a15a08442
-  # -- image pull policy
   pullPolicy: IfNotPresent
 
-# -- Override the args for the default container.
 args: ["server", "/data", "--console-address", ":9001"]
 
 secret:
-    # -- Minio Password
   MINIO_ROOT_PASSWORD: "changeme"
 
-# -- environment variables. See more environment variables in the [minio documentation](https://docs.min.io).
-# @default -- See below
 env:
-  # -- Set the container timezone
-  TZ: UTC
-  # -- Minio Username
+  MINIO_USERNAME: "minio"
+  MINIO_GROUPNAME: "minio"
+  MINIO_UID: "{{ .Values.podSecurityContext.runAsUser }}"
+  MINIO_GID: "{{ .Values.podSecurityContext.runAsGroup }}"
   MINIO_ROOT_USER: "minio"
   MINIO_BROWSER_REDIRECT_URL: ""
 
@@ -29,8 +23,6 @@ probes:
   readiness:
     path: "/minio/health/ready"
 
-# -- Configures service settings for the chart.
-# @default -- See values.yaml
 service:
   main:
     ports:

--- a/charts/stable/minio/values.yaml
+++ b/charts/stable/minio/values.yaml
@@ -13,12 +13,33 @@ env:
   MINIO_BROWSER_REDIRECT_URL: ""
   MINIO_SERVER_URL: ""
 
-probes:
-  liveness:
-    path: "/minio/health/live"
-
   readiness:
     path: "/minio/health/ready"
+
+probes:
+  liveness:
+    enabled: true
+    custom: true
+    spec:
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+      httpGet:
+        path: "/minio/health/live"
+        port: 10106
+  readiness:
+    enabled: true
+    custom: true
+    spec:
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+      httpGet:
+        path: "/minio/health/ready"
+        port: 10106
+
 
 service:
   main:

--- a/charts/stable/minio/values.yaml
+++ b/charts/stable/minio/values.yaml
@@ -29,15 +29,15 @@ service:
   main:
     ports:
       main:
-        port: 10106
-        targetPort: 10106
-  console:
+        port: 10107
+        targetPort: 10107
+  api:
     enabled: true
     ports:
-      console:
+      api:
         enabled: true
-        targetPort: 10107
-        port: 10107
+        targetPort: 10106
+        port: 10106
 
 securityContext:
   readOnlyRootFilesystem: false

--- a/charts/stable/minio/values.yaml
+++ b/charts/stable/minio/values.yaml
@@ -20,15 +20,14 @@ probes:
       httpGet:
         scheme: HTTP
         path: "/minio/health/live"
-        port: 10106
+        port: "{{ .Values.service.api.ports.api.targetPort }}"
   readiness:
     custom: true
     spec:
       httpGet:
         scheme: HTTP
         path: "/minio/health/ready"
-        port: 10106
-
+        port: "{{ .Values.service.api.ports.api.targetPort }}"
 
 service:
   main:

--- a/charts/stable/minio/values.yaml
+++ b/charts/stable/minio/values.yaml
@@ -3,18 +3,20 @@ image:
   tag: latest@sha256:8129f69c85b84e13f085a1ce127f108cee0ea84a1f496e8065796c7a15a08442
   pullPolicy: IfNotPresent
 
-args: ["server", "/data", "--console-address", ":9001"]
+args: ["server", "/data", "--address", ":10106", "--console-address", ":10107"]
 
 secret:
   MINIO_ROOT_PASSWORD: "changeme"
 
 env:
+  # Set User "minio" to run the app with UID/GID from "runAs*"
   MINIO_USERNAME: "minio"
   MINIO_GROUPNAME: "minio"
   MINIO_UID: "{{ .Values.podSecurityContext.runAsUser }}"
   MINIO_GID: "{{ .Values.podSecurityContext.runAsGroup }}"
   MINIO_ROOT_USER: "minio"
   MINIO_BROWSER_REDIRECT_URL: ""
+  MINIO_SERVER_URL: ""
 
 probes:
   liveness:
@@ -28,13 +30,13 @@ service:
     ports:
       main:
         port: 10106
-        targetPort: 9000
+        targetPort: 10106
   console:
     enabled: true
     ports:
       console:
         enabled: true
-        targetPort: 9001
+        targetPort: 10107
         port: 10107
 
 securityContext:

--- a/charts/stable/minio/values.yaml
+++ b/charts/stable/minio/values.yaml
@@ -13,30 +13,19 @@ env:
   MINIO_BROWSER_REDIRECT_URL: ""
   MINIO_SERVER_URL: ""
 
-  readiness:
-    path: "/minio/health/ready"
-
 probes:
   liveness:
-    enabled: true
     custom: true
     spec:
-      initialDelaySeconds: 30
-      periodSeconds: 10
-      timeoutSeconds: 1
-      failureThreshold: 3
       httpGet:
+        scheme: HTTP
         path: "/minio/health/live"
         port: 10106
   readiness:
-    enabled: true
     custom: true
     spec:
-      initialDelaySeconds: 30
-      periodSeconds: 10
-      timeoutSeconds: 1
-      failureThreshold: 3
       httpGet:
+        scheme: HTTP
         path: "/minio/health/ready"
         port: 10106
 

--- a/docs/manual/default-ports.md
+++ b/docs/manual/default-ports.md
@@ -131,8 +131,8 @@ These defaults can of course be changed, but as we guarantee "sane, working defa
 | gaps                       |      main       |      main       | 8484  |   TCP    |                                         |
 | lidarr                     |      main       |      main       | 8686  |   TCP    |                                         |
 | readarr                    |      main       |      main       | 8787  |   TCP    |                                         |
-| omada-controller           |   userportal    |    websecure    | 8843  |  HTTPS   |  Potential conflict with unifi          |
-| unifi                      |   guestportal   |    websecure    | 8843  |  HTTPS   |  Potential conflict with omada          |
+| omada-controller           |   userportal    |    websecure    | 8843  |  HTTPS   |      Potential conflict with unifi      |
+| unifi                      |   guestportal   |    websecure    | 8843  |  HTTPS   |      Potential conflict with omada      |
 | minisatip                  |      main       |      main       | 8875  |   TCP    |                                         |
 | unifi                      |   guestportal   |       web       | 8880  |   HTTP   |                                         |
 | resilio-sync               |      main       |      main       | 8888  |   TCP    |                                         |
@@ -258,8 +258,8 @@ These defaults can of course be changed, but as we guarantee "sane, working defa
 | zigbee2mqtt                |      main       |      main       | 10103 |   TCP    |                                         |
 | tt-rss                     |      main       |      main       | 10104 |   TCP    |                                         |
 | collabora-online           |      main       |      main       | 10105 |   TCP    |                                         |
-| minio                      |      main       |      main       | 10106 |   TCP    |                                         |
-| minio                      |     console     |     console     | 10107 |   TCP    |                                         |
+| minio                      |       api       |       api       | 10106 |   TCP    |                                         |
+| minio                      |      main       |      main       | 10107 |   TCP    |                                         |
 | transmission               |      main       |      main       | 10109 |   TCP    |                                         |
 | anonaddy                   |      main       |      main       | 10110 |   TCP    |                                         |
 | blog                       |      main       |      main       | 10111 |   TCP    |                                         |


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

- ~~According to minio's entrypoint script, we can specify the user we want to run the app.
Now the app can run with `568`, so it should be safe to let the user select the `uid` (via `runAsUser`) and `gid` (`runAsGroup`).
https://github.com/minio/minio/blob/master/dockerscripts/docker-entrypoint.sh~~
Does not seem to be what I though.

- Web portal should work now when clicking the button.
~~Based on this to change the port https://github.com/truenas/charts/pull/296/files#
__It would work right?__
Caveat, it won't use the ingress address for the console, but still point to the lan address.~~
What we can do, is move console to main service, and api to a new api service.

- Console(webui) is now the main service (same port as before), so Portal button will work.
- API(server) is now a new service, which also has an option for ingress now (if I did that right).


---

**Type of change**

- [ ] Feature/App addition
- [x] Bugfix
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor of current code

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Notes:**
<!-- Please enter any other relevant information here -->

**Checklist:**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests to this description that prove my fix is effective or that my feature works
- [x] I increased versions for any altered app according to semantic versioning
