### PR TITLE
fix(automatic-music-downloader): Remove portal, as service is disabled

### DIFF
--- a/charts/incubator/automatic-music-downloader/Chart.yaml
+++ b/charts/incubator/automatic-music-downloader/Chart.yaml
@@ -23,7 +23,7 @@ sources:
 - https://github.com/RandomNinjaAtk/docker-amd
 - https://hub.docker.com/r/randomninjaatk/amd
 type: application
-version: 0.0.1
+version: 0.0.2
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/incubator/automatic-music-downloader/questions.yaml
+++ b/charts/incubator/automatic-music-downloader/questions.yaml
@@ -1,28 +1,5 @@
 # Include{groups}
-portals:
-  web_portal:
-    protocols:
-      - "$kubernetes-resource_configmap_portal_protocol"
-    host:
-      - "$kubernetes-resource_configmap_portal_host"
-    ports:
-      - "$kubernetes-resource_configmap_portal_port"
 questions:
-  - variable: portal
-    group: "Container Image"
-    label: "Configure Portal Button"
-    schema:
-      type: dict
-      hidden: true
-      attrs:
-        - variable: enabled
-          label: "Enable"
-          description: "enable the portal button"
-          schema:
-            hidden: true
-            editable: false
-            type: boolean
-            default: true
   # Include{global}
   - variable: controller
     group: "Controller"

--- a/charts/incubator/automatic-music-downloader/questions.yaml
+++ b/charts/incubator/automatic-music-downloader/questions.yaml
@@ -1,4 +1,5 @@
 # Include{groups}
+portals: {}
 questions:
   # Include{global}
   - variable: controller

--- a/charts/incubator/automatic-music-downloader/questions.yaml
+++ b/charts/incubator/automatic-music-downloader/questions.yaml
@@ -1,6 +1,5 @@
 # Include{groups}
 questions:
-  portals: {}
   # Include{global}
   - variable: controller
     group: "Controller"

--- a/charts/incubator/automatic-music-downloader/questions.yaml
+++ b/charts/incubator/automatic-music-downloader/questions.yaml
@@ -1,6 +1,6 @@
 # Include{groups}
 questions:
-  - portals: {}
+  portals: {}
   # Include{global}
   - variable: controller
     group: "Controller"

--- a/charts/incubator/automatic-music-downloader/questions.yaml
+++ b/charts/incubator/automatic-music-downloader/questions.yaml
@@ -1,5 +1,6 @@
 # Include{groups}
 questions:
+  - portals: {}
   # Include{global}
   - variable: controller
     group: "Controller"


### PR DESCRIPTION
**Description**
Fix to [This PR](https://github.com/truecharts/apps/pull/1902) as requested by @Ornias1993 
⚒️ Fixes  #1902

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
No tests, use CI.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
