### PR TITLE
fix(valheim): Correctly map ports when changed in the UI

### DIFF
--- a/charts/games/valheim/Chart.yaml
+++ b/charts/games/valheim/Chart.yaml
@@ -18,7 +18,7 @@ name: valheim
 sources:
 - https://github.com/lloesche/valheim-server-docker
 - https://hub.docker.com/r/lloesche/valheim-server
-version: 2.0.23
+version: 2.0.24
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/games/valheim/questions.yaml
+++ b/charts/games/valheim/questions.yaml
@@ -297,7 +297,7 @@ questions:
             type: dict
             attrs:
 # Include{serviceSelector}
-                    - variable: valheim-1
+                    - variable: valheim1
                       label: "valheim-1 Service Port Configuration"
                       schema:
                         additional_attrs: true
@@ -345,7 +345,7 @@ questions:
                                     type: int
                                     default: 2456
 
-                    - variable: valheim-2
+                    - variable: valheim2
                       label: "valheim-2 Service Port Configuration"
                       schema:
                         additional_attrs: true
@@ -393,7 +393,7 @@ questions:
                                     type: int
                                     default: 2457
 
-                    - variable: valheim-3
+                    - variable: valheim3
                       label: "valheim-3 Service Port Configuration"
                       schema:
                         additional_attrs: true

--- a/charts/games/valheim/values.yaml
+++ b/charts/games/valheim/values.yaml
@@ -1,26 +1,21 @@
 image:
-  # -- image repository
   repository: tccr.io/truecharts/valheim-server
-  # -- image tag
   tag: latest@sha256:8f87fda54429923cac3601d581d6dc0ff273ef6438374e9f4b1e5ac1141b461d
-  # -- image pull policy
   pullPolicy: IfNotPresent
 
 secret:
   SUPERVISOR_HTTP_USER: admin
   SUPERVISOR_HTTP_PASS: secret
   SERVER_PASS: secret
-# -- environment variables. See [image docs](https://github.com/lloesche/valheim-server-docker#environment-variables) for more details.
-# @default -- See below
+
 env:
-  # -- Set the container timezone
   TZ: UTC
   STATUS_HTTP: true
-  STATUS_HTTP_PORT: 9010
-  SUPERVISOR_HTTP_PORT: 9011
+  STATUS_HTTP_PORT: "{{ .Values.service.main.ports.main.port }}"
+  SUPERVISOR_HTTP_PORT: "{{ .Values.service.supervisor.ports.supervisor.port }}"
   SUPERVISOR_HTTP: true
   SERVER_NAME: My Server
-  SERVER_PORT: 2456
+  SERVER_PORT: "{{ .Values.service.valheim.ports.valheim-1.port }}"
   WORLD_NAME: Dedicated
   SERVER_PUBLIC: true
   UPDATE_INTERVAL: 10800
@@ -37,21 +32,19 @@ podSecurityContext:
   runAsUser: 0
   runAsGroup: 0
 
-# -- Configures service settings for the chart.
-# @default -- See values.yaml
 service:
   main:
     ports:
       main:
         port: 9010
-        targetPort: 9010
+        targetPort: "{{ .Values.service.main.ports.main.port }}"
   supervisor:
     enabled: true
     ports:
       supervisor:
         enabled: true
         port: 9011
-        targetPort: 9011
+        targetPort: "{{ .Values.service.supervisor.ports.supervisor.port }}"
   valheim:
     enabled: true
     type: LoadBalancer
@@ -59,21 +52,19 @@ service:
       valheim-1:
         enabled: true
         port: 2456
-        targetPort: 2456
+        targetPort: "{{ .Values.service.valheim.ports.valheim-1.port }}"
         protocol: UDP
       valheim-2:
         enabled: true
         port: 2457
-        targetPort: 2457
+        targetPort: "{{ .Values.service.valheim.ports.valheim-2.port }}"
         protocol: UDP
       valheim-3:
         enabled: true
         port: 2458
         protocol: UDP
-        targetPort: 2458
+        targetPort: "{{ .Values.service.valheim.ports.valheim-3.port }}"
 
-# -- Configure persistence settings for the chart under this key.
-# @default -- See values.yaml
 persistence:
   config:
     enabled: true

--- a/charts/games/valheim/values.yaml
+++ b/charts/games/valheim/values.yaml
@@ -11,11 +11,11 @@ secret:
 env:
   TZ: UTC
   STATUS_HTTP: true
-  STATUS_HTTP_PORT: "{{ .Values.service.main.ports.main.port }}"
-  SUPERVISOR_HTTP_PORT: "{{ .Values.service.supervisor.ports.supervisor.port }}"
+  STATUS_HTTP_PORT: "{{ .Values.service.main.ports.main.targetPort }}"
+  SUPERVISOR_HTTP_PORT: "{{ .Values.service.supervisor.ports.supervisor.targetPort }}"
   SUPERVISOR_HTTP: true
   SERVER_NAME: My Server
-  SERVER_PORT: "{{ .Values.service.valheim.ports.valheim1.port }}"
+  SERVER_PORT: "{{ .Values.service.valheim.ports.valheim1.targetPort }}"
   WORLD_NAME: Dedicated
   SERVER_PUBLIC: true
   UPDATE_INTERVAL: 10800
@@ -37,14 +37,14 @@ service:
     ports:
       main:
         port: 9010
-        targetPort: "{{ .Values.service.main.ports.main.port }}"
+        targetPort: 9010
   supervisor:
     enabled: true
     ports:
       supervisor:
         enabled: true
         port: 9011
-        targetPort: "{{ .Values.service.supervisor.ports.supervisor.port }}"
+        targetPort: 9011
   valheim:
     enabled: true
     type: LoadBalancer
@@ -52,18 +52,18 @@ service:
       valheim1:
         enabled: true
         port: 2456
-        targetPort: "{{ .Values.service.valheim.ports.valheim1.port }}"
+        targetPort: 2456
         protocol: UDP
       valheim2:
         enabled: true
         port: 2457
-        targetPort: "{{ .Values.service.valheim.ports.valheim2.port }}"
+        targetPort: 2457
         protocol: UDP
       valheim3:
         enabled: true
         port: 2458
         protocol: UDP
-        targetPort: "{{ .Values.service.valheim.ports.valheim3.port }}"
+        targetPort: 2458
 
 persistence:
   config:

--- a/charts/games/valheim/values.yaml
+++ b/charts/games/valheim/values.yaml
@@ -11,11 +11,11 @@ secret:
 env:
   TZ: UTC
   STATUS_HTTP: true
-  STATUS_HTTP_PORT: "{{ .Values.service.main.ports.main.targetPort }}"
-  SUPERVISOR_HTTP_PORT: "{{ .Values.service.supervisor.ports.supervisor.targetPort }}"
+  STATUS_HTTP_PORT: "{{ .Values.service.main.ports.main.port }}"
+  SUPERVISOR_HTTP_PORT: "{{ .Values.service.supervisor.ports.supervisor.port }}"
   SUPERVISOR_HTTP: true
   SERVER_NAME: My Server
-  SERVER_PORT: "{{ .Values.service.valheim.ports.valheim1.targetPort }}"
+  SERVER_PORT: "{{ .Values.service.valheim.ports.valheim1.port }}"
   WORLD_NAME: Dedicated
   SERVER_PUBLIC: true
   UPDATE_INTERVAL: 10800
@@ -37,14 +37,12 @@ service:
     ports:
       main:
         port: 9010
-        targetPort: 9010
   supervisor:
     enabled: true
     ports:
       supervisor:
         enabled: true
         port: 9011
-        targetPort: 9011
   valheim:
     enabled: true
     type: LoadBalancer
@@ -52,18 +50,15 @@ service:
       valheim1:
         enabled: true
         port: 2456
-        targetPort: 2456
         protocol: UDP
       valheim2:
         enabled: true
         port: 2457
-        targetPort: 2457
         protocol: UDP
       valheim3:
         enabled: true
         port: 2458
         protocol: UDP
-        targetPort: 2458
 
 persistence:
   config:

--- a/charts/games/valheim/values.yaml
+++ b/charts/games/valheim/values.yaml
@@ -15,7 +15,7 @@ env:
   SUPERVISOR_HTTP_PORT: "{{ .Values.service.supervisor.ports.supervisor.port }}"
   SUPERVISOR_HTTP: true
   SERVER_NAME: My Server
-  SERVER_PORT: "{{ .Values.service.valheim.ports.valheim-1.port }}"
+  SERVER_PORT: "{{ .Values.service.valheim.ports.valheim1.port }}"
   WORLD_NAME: Dedicated
   SERVER_PUBLIC: true
   UPDATE_INTERVAL: 10800
@@ -49,21 +49,21 @@ service:
     enabled: true
     type: LoadBalancer
     ports:
-      valheim-1:
+      valheim1:
         enabled: true
         port: 2456
-        targetPort: "{{ .Values.service.valheim.ports.valheim-1.port }}"
+        targetPort: "{{ .Values.service.valheim.ports.valheim1.port }}"
         protocol: UDP
-      valheim-2:
+      valheim2:
         enabled: true
         port: 2457
-        targetPort: "{{ .Values.service.valheim.ports.valheim-2.port }}"
+        targetPort: "{{ .Values.service.valheim.ports.valheim2.port }}"
         protocol: UDP
-      valheim-3:
+      valheim3:
         enabled: true
         port: 2458
         protocol: UDP
-        targetPort: "{{ .Values.service.valheim.ports.valheim-3.port }}"
+        targetPort: "{{ .Values.service.valheim.ports.valheim3.port }}"
 
 persistence:
   config:

--- a/charts/games/valheim/values.yaml
+++ b/charts/games/valheim/values.yaml
@@ -36,14 +36,14 @@ service:
   main:
     ports:
       main:
-        port: "{{ .Values.service.main.ports.main.targetPort }}"
+        port: 9010
         targetPort: 9010
   supervisor:
     enabled: true
     ports:
       supervisor:
         enabled: true
-        port: "{{ .Values.service.supervisor.ports.supervisor.targetPort }}"
+        port: 9011
         targetPort: 9011
   valheim:
     enabled: true
@@ -51,17 +51,17 @@ service:
     ports:
       valheim1:
         enabled: true
-        port: "{{ .Values.service.valheim.ports.valheim1.targetPort }}"
+        port: 2456
         targetPort: 2456
         protocol: UDP
       valheim2:
         enabled: true
-        port: "{{ .Values.service.valheim.ports.valheim2.targetPort }}"
+        port: 2457
         targetPort: 2457
         protocol: UDP
       valheim3:
         enabled: true
-        port: "{{ .Values.service.valheim.ports.valheim3.targetPort }}"
+        port: 2458
         protocol: UDP
         targetPort: 2458
 

--- a/charts/games/valheim/values.yaml
+++ b/charts/games/valheim/values.yaml
@@ -36,14 +36,14 @@ service:
   main:
     ports:
       main:
-        port: 9010
+        port: "{{ .Values.service.main.ports.main.targetPort }}"
         targetPort: 9010
   supervisor:
     enabled: true
     ports:
       supervisor:
         enabled: true
-        port: 9011
+        port: "{{ .Values.service.supervisor.ports.supervisor.targetPort }}"
         targetPort: 9011
   valheim:
     enabled: true
@@ -51,17 +51,17 @@ service:
     ports:
       valheim1:
         enabled: true
-        port: 2456
+        port: "{{ .Values.service.valheim.ports.valheim1.targetPort }}"
         targetPort: 2456
         protocol: UDP
       valheim2:
         enabled: true
-        port: 2457
+        port: "{{ .Values.service.valheim.ports.valheim2.targetPort }}"
         targetPort: 2457
         protocol: UDP
       valheim3:
         enabled: true
-        port: 2458
+        port: "{{ .Values.service.valheim.ports.valheim3.targetPort }}"
         protocol: UDP
         targetPort: 2458
 

--- a/docs/apps/games/valheim/notes.md
+++ b/docs/apps/games/valheim/notes.md
@@ -1,0 +1,8 @@
+# Installation Notes
+
+Valheim app does not support having different port numbers for `port` and `targetPort`.
+Setting `port` will set the same port number to `targetPort` and it's Environmental Variable.
+e.g `STATUS_HTTP_PORT`, `SUPERVISOR_HTTP_PORT`, `SERVER_PORT`
+
+Also, services named `valheim1`, `valheim2`, `valheim3`, should be continuous port numbers. eg 2456, 2457, 2458.
+You can't skip a number!


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #1899 

When a user changes port in the UI, valheim internally still reported the original ports set in env.
This PR, will update the env's with the new ports defined by user, BUT user must expand the Advanced options and change both `port` and `targetPort`.

Deviating from default ports, is considered an advanced option anyway.


**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
