### PR TITLE
feat(common): add autolinking opion to ingress

### DIFF
--- a/charts/library/common-test/ci/ingress-values.yaml
+++ b/charts/library/common-test/ci/ingress-values.yaml
@@ -8,6 +8,12 @@ service:
     ports:
       main:
         port: 8080
+  autolink:
+    enabled: true
+    ports:
+      autolink:
+        enabled: true
+        port: 8081
 
 args:
   - --port
@@ -70,6 +76,21 @@ ingress:
               name:
               port:
     tls: []
+
+  autolink:
+    enabled: true
+    fixedMiddlewares:
+      - chain-basic
+    hosts:
+      - host: label.chart-example.local
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              name:
+              port:
+    tls: []
+    autoLink: true
 
   labellist:
     enabled: true

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 8.15.4
+version: 8.16.0

--- a/charts/library/common/templates/classes/_ingress.tpl
+++ b/charts/library/common/templates/classes/_ingress.tpl
@@ -18,11 +18,19 @@ within the common library.
   {{- end -}}
 
   {{- $primaryService := get .Values.service (include "common.service.primary" .) -}}
+  {{- $autoLinkService := get .Values.service (include "common.service.primary" .) -}}
   {{- $defaultServiceName := $fullName -}}
   {{- if and (hasKey $primaryService "nameOverride") $primaryService.nameOverride -}}
     {{- $defaultServiceName = printf "%v-%v" $defaultServiceName $primaryService.nameOverride -}}
   {{- end -}}
   {{- $defaultServicePort := get $primaryService.ports (include "common.classes.service.ports.primary" (dict "values" $primaryService)) -}}
+
+  {{- if and (hasKey $values "nameOverride") ( $values.nameOverride ) ( $values.autoLink ) -}}
+    {{- $autoLinkService = get .Values.service $values.nameOverride -}}
+    {{- $defaultServiceName = $ingressName -}}
+    {{- $defaultServicePort = get $autoLinkService.ports $values.nameOverride -}}
+  {{- end -}}
+
 
   {{- $isStable := include "common.capabilities.ingress.isStable" . }}
 

--- a/charts/library/common/values.yaml
+++ b/charts/library/common/values.yaml
@@ -530,6 +530,9 @@ ingress:
     # -- Override the name suffix that is used for this ingress.
     nameOverride:
 
+    # -- Autolink the ingress to a service and port, both with the same name as the ingress.
+    autoLink: false
+
     # -- disable to ignore any default middlwares
     enableFixedMiddlewares: true
 


### PR DESCRIPTION
**Description**
Previously we supported autolinking the ingress to a service with the same name.
This brings back that behavior as an option in case it's needed for a specific App.

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
