### PR TITLE
fix(apps): Removed some double `b64enc` on autogenerated secrets, also some quotes off them.

### DIFF
--- a/charts/stable/anonaddy/Chart.yaml
+++ b/charts/stable/anonaddy/Chart.yaml
@@ -25,7 +25,7 @@ maintainers:
 name: anonaddy
 sources:
 - https://github.com/anonaddy/docker
-version: 6.0.38
+version: 6.0.39
 annotations:
   truecharts.org/catagories: |
     - email

--- a/charts/stable/anonaddy/templates/_appkey.tpl
+++ b/charts/stable/anonaddy/templates/_appkey.tpl
@@ -5,6 +5,7 @@ This template generates a random password and ensures it persists across updates
 ---
 apiVersion: v1
 kind: Secret
+type: Opaque
 metadata:
   labels:
     {{- include "common.labels" . | nindent 4 }}
@@ -14,15 +15,14 @@ metadata:
 {{- $secret := "" }}
 data:
 {{- if $keyprevious }}
-  {{- $appkey = ( index $keyprevious.data "appkey" ) | b64dec  }}
-  {{- $secret = ( index $keyprevious.data "secret" ) | b64dec  }}
+  {{- $appkey = ( index $keyprevious.data "appkey" ) }}
+  {{- $secret = ( index $keyprevious.data "secret" ) }}
   appkey: {{ ( index $keyprevious.data "appkey" ) }}
   secret: {{ ( index $keyprevious.data "secret" ) }}
 {{- else }}
-  {{- $appkey = randAlphaNum 32 | b64enc }}
-  {{- $secret = randAlphaNum 32 | b64enc }}
-  appkey: {{ $appkey | b64enc | quote }}
-  secret: {{ $secret | b64enc | quote }}
+  {{- $appkey = randAlphaNum 32 }}
+  {{- $secret = randAlphaNum 32 }}
+  appkey: {{ $appkey | b64enc }}
+  secret: {{ $secret | b64enc }}
 {{- end }}
-type: Opaque
 {{- end -}}

--- a/charts/stable/authelia/Chart.yaml
+++ b/charts/stable/authelia/Chart.yaml
@@ -38,7 +38,7 @@ sources:
 - https://github.com/authelia/chartrepo
 - https://github.com/authelia/authelia
 type: application
-version: 8.0.40
+version: 8.0.41
 annotations:
   truecharts.org/catagories: |
     - security

--- a/charts/stable/authelia/templates/_secrets.tpl
+++ b/charts/stable/authelia/templates/_secrets.tpl
@@ -21,15 +21,15 @@ data:
   ENCRYPTION_KEY: {{ index $autheliaprevious.data "ENCRYPTION_KEY"  }}
   {{- else }}
   {{- $encryptionkey := randAlphaNum 100 }}
-  ENCRYPTION_KEY: {{ $encryptionkey | b64enc | quote }}
+  ENCRYPTION_KEY: {{ $encryptionkey | b64enc }}
   {{- end }}
   {{- else }}
   {{- $jwtsecret := randAlphaNum 50 }}
   {{- $sessionsecret := randAlphaNum 50 }}
   {{- $encryptionkey := randAlphaNum 100 }}
-  SESSION_ENCRYPTION_KEY: {{ $sessionsecret | b64enc | quote }}
-  JWT_TOKEN: {{ $jwtsecret | b64enc | quote }}
-  ENCRYPTION_KEY: {{ $encryptionkey | b64enc | quote }}
+  SESSION_ENCRYPTION_KEY: {{ $sessionsecret | b64enc }}
+  JWT_TOKEN: {{ $jwtsecret | b64enc}}
+  ENCRYPTION_KEY: {{ $encryptionkey | b64enc }}
   {{- end }}
 
   {{- if .Values.authentication_backend.ldap.enabled }}

--- a/charts/stable/fireflyiii/Chart.yaml
+++ b/charts/stable/fireflyiii/Chart.yaml
@@ -28,7 +28,7 @@ name: fireflyiii
 sources:
 - https://github.com/firefly-iii/firefly-iii/
 type: application
-version: 13.1.27
+version: 13.1.28
 annotations:
   truecharts.org/catagories: |
     - finacial

--- a/charts/stable/fireflyiii/templates/_secrets.tpl
+++ b/charts/stable/fireflyiii/templates/_secrets.tpl
@@ -17,8 +17,8 @@ data:
   {{- else }}
   {{- $static_cron_token := randAlphaNum 32 }}
   {{- $app_key := randAlphaNum 32 }}
-  STATIC_CRON_TOKEN: {{ $static_cron_token | b64enc | quote }}
-  APP_KEY: {{ $static_cron_token | b64enc | quote }}
+  STATIC_CRON_TOKEN: {{ $static_cron_token | b64enc }}
+  APP_KEY: {{ $static_cron_token | b64enc }}
   {{- end }}
 
 {{- end -}}

--- a/charts/stable/leantime/Chart.yaml
+++ b/charts/stable/leantime/Chart.yaml
@@ -24,7 +24,7 @@ name: leantime
 sources:
   - https://leantime.io/
   - https://hub.docker.com/r/nicholaswilde/leantime
-version: 1.0.20
+version: 1.0.21
 annotations:
   truecharts.org/catagories: |
     - management

--- a/charts/stable/leantime/templates/_secrets.tpl
+++ b/charts/stable/leantime/templates/_secrets.tpl
@@ -14,7 +14,7 @@ data:
   LEAN_SESSION_PASSWORD: {{ index $leantimeprevious.data "LEAN_SESSION_PASSWORD" }}
   {{- else }}
   {{- $session_password := randAlphaNum 32 }}
-  LEAN_SESSION_PASSWORD: {{ $session_password | b64enc | quote }}
+  LEAN_SESSION_PASSWORD: {{ $session_password | b64enc }}
   {{- end }}
 
 {{- end -}}

--- a/charts/stable/librephotos/Chart.yaml
+++ b/charts/stable/librephotos/Chart.yaml
@@ -27,7 +27,7 @@ name: librephotos
 sources:
 - https://github.com/LibrePhotos/librephotos
 - https://hub.docker.com/r/reallibrephotos/librephotos
-version: 1.0.3
+version: 1.0.4
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/librephotos/templates/_secrets.tpl
+++ b/charts/stable/librephotos/templates/_secrets.tpl
@@ -14,7 +14,7 @@ data:
   SECRET_KEY: {{ index $librephotosprevious.data "SECRET_KEY" }}
   {{- else }}
   {{- $secret_key := randAlphaNum 32 }}
-  SECRET_KEY: {{ $secret_key | b64enc | quote }}
+  SECRET_KEY: {{ $secret_key | b64enc }}
   {{- end }}
 
 {{- end -}}

--- a/charts/stable/linkace/Chart.yaml
+++ b/charts/stable/linkace/Chart.yaml
@@ -27,7 +27,7 @@ sources:
 - https://www.linkace.org/docs/
 - https://github.com/linkace/linkace
 - https://hub.docker.com/r/linkace/linkace
-version: 1.0.3
+version: 1.0.4
 annotations:
   truecharts.org/catagories: |
     - media

--- a/charts/stable/linkace/templates/_secrets.tpl
+++ b/charts/stable/linkace/templates/_secrets.tpl
@@ -14,7 +14,7 @@ data:
   APP_KEY: {{ index $linkaceprevious.data "APP_KEY" }}
   {{- else }}
   {{- $app_key := randAlphaNum 32 }}
-  APP_KEY: {{ $app_key | b64enc | quote }}
+  APP_KEY: {{ $app_key | b64enc }}
   {{- end }}
 
 {{- end -}}

--- a/charts/stable/paperless-ng/Chart.yaml
+++ b/charts/stable/paperless-ng/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: paperless-ng
-version: 1.0.21
+version: 1.0.22
 appVersion: "1.5.0"
 description: Paperless-ng is an application by Daniel Quinn and contributors that indexes your scanned documents.
 type: application

--- a/charts/stable/paperless-ng/templates/_sercrets.tpl
+++ b/charts/stable/paperless-ng/templates/_sercrets.tpl
@@ -14,7 +14,7 @@ data:
   PAPERLESS_SECRET_KEY: {{ index $paperlessprevious.data "PAPERLESS_SECRET_KEY" }}
   {{- else }}
   {{- $secret_key := randAlphaNum 32 }}
-  PAPERLESS_SECRET_KEY: {{ $secret_key | b64enc | quote }}
+  PAPERLESS_SECRET_KEY: {{ $secret_key | b64enc  }}
   {{- end }}
 
 {{- end -}}

--- a/charts/stable/pydio-cells/Chart.yaml
+++ b/charts/stable/pydio-cells/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 kubeVersion: ">=1.16.0-0"
 name: pydio-cells
-version: 1.0.1
+version: 1.0.2
 appVersion: "3.0.4"
 description: Pydio-cells is the nextgen file sharing platform for organizations.
 type: application

--- a/charts/stable/pydio-cells/templates/_configmap.tpl
+++ b/charts/stable/pydio-cells/templates/_configmap.tpl
@@ -17,5 +17,5 @@ data:
     dbTCPPort: 3306
     dbTCPName: {{ .Values.mariadb.mariadbDatabase }}
     dbTCPUser: {{ .Values.mariadb.mariadbUsername }}
-    dbTCPPassword: {{ .Values.mariadb.mariadbPassword }}
+    dbTCPPassword: {{ .Values.mariadb.mariadbPassword | trimAll "\"" }}
 {{- end -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

Removing quotes should not affect already deployed apps. As it will still use the "previous" key.

I'm not sure what will happen to apps that had double `b64enc` on their keys.
But probably they are either already not working, or they might cause problems in later?

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
