### PR TITLE
feat(common): allow shared ip

### DIFF
--- a/charts/library/common/templates/classes/_service.tpl
+++ b/charts/library/common/templates/classes/_service.tpl
@@ -30,6 +30,9 @@ metadata:
   {{- if eq ( $primaryPort.protocol | default "" ) "HTTPS" }}
     traefik.ingress.kubernetes.io/service.serversscheme: https
   {{- end }}
+  {{- if eq ( $svcType | default "" ) "LoadBalancer" }}
+    metallb.universe.tf/allow-shared-ip: {{ include "common.names.fullname" . }}
+  {{- end }}
   {{- with $values.annotations }}
     {{ toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
**Description**

By default, Services do not share IP addresses. Enable by adding the metallb.universe.tf/allow-shared-ip annotation to services to solve the problem that multiple services have multiple IPs in one application

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**

Here is an example configuration of two services that share the same ip address:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: dns-service-tcp
  namespace: default
  annotations:
    metallb.universe.tf/allow-shared-ip: "common.names.fullname"
spec:
  type: LoadBalancer
  loadBalancerIP: 1.2.3.4
  ports:
    - name: dnstcp
      protocol: TCP
      port: 53
      targetPort: 53
  selector:
    app: dns
---
apiVersion: v1
kind: Service
metadata:
  name: dns-service-udp
  namespace: default
  annotations:
    metallb.universe.tf/allow-shared-ip: "common.names.fullname"
spec:
  type: LoadBalancer
  loadBalancerIP: 1.2.3.4
  ports:
    - name: dnsudp
      protocol: UDP
      port: 53
      targetPort: 53
  selector:
    app: dns
```

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
