### PR TITLE
feat(common): allow more PUID/UID types to sync with GUID/GID

### DIFF
--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 9.1.0
+version: 9.1.1

--- a/charts/library/common/templates/lib/controller/_container.tpl
+++ b/charts/library/common/templates/lib/controller/_container.tpl
@@ -48,6 +48,10 @@
   env:
     - name: PUID
       value: {{ .Values.security.PUID | quote }}
+    - name: USER_ID
+      value: {{ .Values.security.PUID | quote }}
+    - name: UID
+      value: {{ .Values.security.PUID | quote }}
     - name: UMASK
       value: {{ .Values.security.UMASK | quote }}
     - name: UMASK_SET

--- a/tests/library/common/container_spec.rb
+++ b/tests/library/common/container_spec.rb
@@ -85,7 +85,7 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_nil(mainContainer["env"][9])
+        assert_nil(mainContainer["env"][11])
       end
 
       it 'set static "k/v pair style" environment variables' do
@@ -101,14 +101,14 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][9]["name"])
-        assert_equal(values[:env].values[0].to_s, mainContainer["env"][9]["value"])
-        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][10]["name"])
-        assert_equal(values[:env].values[1].to_s, mainContainer["env"][10]["value"])
-        assert_equal(values[:env].keys[2].to_s, mainContainer["env"][11]["name"])
-        assert_equal(values[:env].values[2].to_s, mainContainer["env"][11]["value"])
-        assert_equal(values[:env].keys[3].to_s, mainContainer["env"][12]["name"])
-        assert_equal(values[:env].values[3].to_s, mainContainer["env"][12]["value"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][11]["name"])
+        assert_equal(values[:env].values[0].to_s, mainContainer["env"][11]["value"])
+        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][12]["name"])
+        assert_equal(values[:env].values[1].to_s, mainContainer["env"][12]["value"])
+        assert_equal(values[:env].keys[2].to_s, mainContainer["env"][13]["name"])
+        assert_equal(values[:env].values[2].to_s, mainContainer["env"][13]["value"])
+        assert_equal(values[:env].keys[3].to_s, mainContainer["env"][14]["name"])
+        assert_equal(values[:env].values[3].to_s, mainContainer["env"][14]["value"])
       end
 
       it 'set list of static "kubernetes style" environment variables' do
@@ -124,8 +124,8 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:envList][0][:name].to_s, mainContainer["env"][9]["name"])
-        assert_equal(values[:envList][0][:value].to_s, mainContainer["env"][9]["value"])
+        assert_equal(values[:envList][0][:name].to_s, mainContainer["env"][11]["name"])
+        assert_equal(values[:envList][0][:value].to_s, mainContainer["env"][11]["value"])
       end
 
       it 'set both static "k/v pair style" and static "k/valueFrom style" environment variables' do
@@ -145,10 +145,10 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][9]["name"])
-        assert_equal(values[:env].values[0].to_s, mainContainer["env"][9]["value"])
-        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][10]["name"])
-        assert_equal(values[:env].values[1][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][10]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][11]["name"])
+        assert_equal(values[:env].values[0].to_s, mainContainer["env"][11]["value"])
+        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][12]["name"])
+        assert_equal(values[:env].values[1][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][12]["valueFrom"]["fieldRef"]["fieldPath"])
       end
 
       it 'set static "k/explicitValueFrom pair style" environment variables' do
@@ -167,8 +167,8 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][9]["name"])
-        assert_equal(values[:env].values[0][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][9]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][11]["name"])
+        assert_equal(values[:env].values[0][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][11]["valueFrom"]["fieldRef"]["fieldPath"])
       end
 
       it 'set static "k/implicitValueFrom pair style" environment variables' do
@@ -185,8 +185,8 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][9]["name"])
-        assert_equal(values[:env].values[0][:fieldRef][:fieldPath], mainContainer["env"][9]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][11]["name"])
+        assert_equal(values[:env].values[0][:fieldRef][:fieldPath], mainContainer["env"][11]["valueFrom"]["fieldRef"]["fieldPath"])
       end
 
       it 'set both static "k/v pair style" and templated "k/v pair style" environment variables' do
@@ -200,10 +200,10 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][9]["name"])
-        assert_equal("common-test-admin", mainContainer["env"][9]["value"])
-        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][10]["name"])
-        assert_equal(values[:env].values[1].to_s, mainContainer["env"][10]["value"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][11]["name"])
+        assert_equal("common-test-admin", mainContainer["env"][11]["value"])
+        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][12]["name"])
+        assert_equal(values[:env].values[1].to_s, mainContainer["env"][12]["value"])
       end
 
       it 'set templated "k/v pair style" environment variables' do
@@ -216,8 +216,8 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][9]["name"])
-        assert_equal("common-test-admin", mainContainer["env"][9]["value"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][11]["name"])
+        assert_equal("common-test-admin", mainContainer["env"][11]["value"])
       end
 
       it 'set static "k/v pair style", templated "k/v pair style", static "k/explicitValueFrom pair style", and static "k/implicitValueFrom pair style" environment variables' do
@@ -243,14 +243,14 @@ class Test < ChartTest
         deployment = chart.resources(kind: "Deployment").first
         containers = deployment["spec"]["template"]["spec"]["containers"]
         mainContainer = containers.find{ |c| c["name"] == "common-test" }
-        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][9]["name"])
-        assert_equal("common-test-admin", mainContainer["env"][9]["value"])
-        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][10]["name"])
-        assert_equal(values[:env].values[1].to_s, mainContainer["env"][10]["value"])
-        assert_equal(values[:env].keys[2].to_s, mainContainer["env"][11]["name"])
-        assert_equal(values[:env].values[2][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][11]["valueFrom"]["fieldRef"]["fieldPath"])
-        assert_equal(values[:env].keys[3].to_s, mainContainer["env"][12]["name"])
-        assert_equal(values[:env].values[3][:fieldRef][:fieldPath], mainContainer["env"][12]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:env].keys[0].to_s, mainContainer["env"][11]["name"])
+        assert_equal("common-test-admin", mainContainer["env"][11]["value"])
+        assert_equal(values[:env].keys[1].to_s, mainContainer["env"][12]["name"])
+        assert_equal(values[:env].values[1].to_s, mainContainer["env"][12]["value"])
+        assert_equal(values[:env].keys[2].to_s, mainContainer["env"][13]["name"])
+        assert_equal(values[:env].values[2][:valueFrom][:fieldRef][:fieldPath], mainContainer["env"][13]["valueFrom"]["fieldRef"]["fieldPath"])
+        assert_equal(values[:env].keys[3].to_s, mainContainer["env"][14]["name"])
+        assert_equal(values[:env].values[3][:fieldRef][:fieldPath], mainContainer["env"][14]["valueFrom"]["fieldRef"]["fieldPath"])
       end
 
       it 'set "static" secret variables' do


### PR DESCRIPTION
**Description**
Currently we only set PUID by default, but there are two other frequently used ways of defining a process user id.
This PR adds those two other ways of defining PUID, just like we did with GUID before

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
