### PR TITLE
adding quick-start guide as a link

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -26,11 +26,9 @@ All our apps are supposed to work together, be easy to setup using the TrueNAS U
 [![docs](https://img.shields.io/badge/docs-rtfm-yellow?logo=gitbook&logoColor=white&style=for-the-badge)](https://truecharts.org/)
 
 ---
-
 Installing TrueCharts within TrueNAS SCALE, is possible using the TrueNAS SCALE Catalog list.
 
-For more information:
-https://truecharts.org/manual/Quick-Start%20Guides/01-Adding-TrueCharts/
+Check TrueCharts [Quick-Start Guides](https://truecharts.org/manual/Quick-Start%20Guides/01-Adding-TrueCharts/) for more infotmation.
 
 ### Support
 

--- a/docs/apps/library/common-test/CONFIG.md
+++ b/docs/apps/library/common-test/CONFIG.md
@@ -1,8 +1,7 @@
 # Configuration Options
 
 ##### Connecting to other apps
-If you need to connect this App to other Apps on TrueNAS SCALE, please refer to our "Linking Apps Internally" quick-start guide:
-https://truecharts.org/manual/Quick-Start%20Guides/14-linking-apps/
+If you need to connect this App to other Apps on TrueNAS SCALE, please refer to our [Linking Apps Internally](https://truecharts.org/manual/Quick-Start%20Guides/06-linking-apps/) quick-start guide.
 
 ##### Available config options
 In the future this page is going to contain an automated list of options available in the installation/edit UI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,8 +34,8 @@ All our apps are supposed to work together, be easy to setup using the TrueNAS U
 
 Installing TrueCharts within TrueNAS SCALE, is possible using the TrueNAS SCALE Catalog list.
 
-For more information:
-https://truecharts.org/manual/Quick-Start%20Guides/01-Adding-TrueCharts/
+Check TrueCharts [Quick-Start Guides](https://truecharts.org/manual/Quick-Start%20Guides/01-Adding-TrueCharts/) for more infotmation.
+
 
 ### Support
 

--- a/templates/docs/CONFIG.md.gotmpl
+++ b/templates/docs/CONFIG.md.gotmpl
@@ -6,8 +6,7 @@
 {{ template "custom.custom.configuration.header" . }}
 
 ##### Connecting to other apps
-If you need to connect this App to other Apps on TrueNAS SCALE, please refer to our "Linking Apps Internally" quick-start guide:
-https://truecharts.org/manual/Quick-Start%20Guides/14-linking-apps/
+If you need to connect this App to other Apps on TrueNAS SCALE, please refer to our [Linking Apps Internally](https://truecharts.org/manual/Quick-Start%20Guides/06-linking-apps/) quick-start guide.
 
 ##### Available config options
 In the future this page is going to contain an automated list of options available in the installation/edit UI.


### PR DESCRIPTION
Improving UX only as it was strange to keep this as a text. It did not highlight as URL so I had to copy-paste it to the browser