### PR TITLE
fix(templates): make security questions overridable in values

### DIFF
--- a/charts/stable/uptime-kuma/Chart.yaml
+++ b/charts/stable/uptime-kuma/Chart.yaml
@@ -20,7 +20,7 @@ name: uptime-kuma
 sources:
 - https://github.com/louislam/uptime-kuma
 type: application
-version: 2.0.4
+version: 2.0.5
 annotations:
   truecharts.org/catagories: |
     - monitoring

--- a/charts/stable/uptime-kuma/values.yaml
+++ b/charts/stable/uptime-kuma/values.yaml
@@ -10,6 +10,9 @@ podSecurityContext:
   runAsUser: 0
   runAsGroup: 0
 
+security:
+  PUID: 0
+
 service:
   main:
     ports:

--- a/templates/questions/security.yaml
+++ b/templates/questions/security.yaml
@@ -6,8 +6,8 @@
       additional_attrs: true
       attrs:
         - variable: editsecurity
-          label: "Enable Security and Permission Settings"
-          description: "By enabling this you override predefined set values."
+          label: "Change PUID / UMASK values"
+          description: "By enabling this you override default set values."
           schema:
             type: boolean
             default: false

--- a/templates/questions/security.yaml
+++ b/templates/questions/security.yaml
@@ -5,15 +5,23 @@
       type: dict
       additional_attrs: true
       attrs:
-        - variable: PUID
-          label: "Process User ID - PUID"
-          description: "When supported by the container, this sets the User ID running the Application Process. Not supported by all Apps"
+        - variable: editsecurity
+          label: "Enable Security and Permission Settings"
+          description: "By enabling this you override predefined set values."
           schema:
-            type: int
-            default: 568
-        - variable: UMASK
-          label: "UMASK"
-          description: "When supported by the container, this sets the UMASK for tha App. Not supported by all Apps"
-          schema:
-            type: string
-            default: "002"
+            type: boolean
+            default: false
+            show_subquestions_if: true
+            subquestions:
+              - variable: PUID
+                label: "Process User ID - PUID"
+                description: "When supported by the container, this sets the User ID running the Application Process. Not supported by all Apps"
+                schema:
+                  type: int
+                  default: 568
+              - variable: UMASK
+                label: "UMASK"
+                description: "When supported by the container, this sets the UMASK for tha App. Not supported by all Apps"
+                schema:
+                  type: string
+                  default: "002"


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #2184

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->
Currently there is no way to override PUID (or UMASK) in values.yaml, as the questions has a default already and this will be used no matter what.

Use case for this is: `uptime-kuma` requires `PUID: 0` for `ping` probes to work.

By hidding those behind a checkbox, we can set PUID: 0 in values and it will work when deployed.

Other solution would be to get rid of the include template and just place it in question yaml.
Then apply the default value to gui as well (just like what we do for runasuser/group etc)

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
