### PR TITLE
fix(mariadb): Wait for init

### DIFF
--- a/charts/dependency/mariadb/Chart.yaml
+++ b/charts/dependency/mariadb/Chart.yaml
@@ -24,7 +24,7 @@ sources:
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
 type: application
-version: 2.0.7
+version: 2.0.8
 annotations:
   truecharts.org/catagories: |
     - database

--- a/charts/dependency/mariadb/values.yaml
+++ b/charts/dependency/mariadb/values.yaml
@@ -62,7 +62,7 @@ probes:
         command:
           - /bin/bash
           - -ec
-          - mysqladmin status -uroot -p"${MARIADB_ROOT_PASSWORD}"
+          - "/opt/bitnami/scripts/mariadb/healthcheck.sh"
 
   # -- Redainess probe configuration
   # @default -- See below
@@ -79,7 +79,7 @@ probes:
         command:
           - /bin/bash
           - -ec
-          - mysqladmin status -uroot -p"${MARIADB_ROOT_PASSWORD}"
+          - "/opt/bitnami/scripts/mariadb/healthcheck.sh"
   # -- Startup probe configuration
   # @default -- See below
   startup:
@@ -94,7 +94,7 @@ probes:
         command:
           - /bin/bash
           - -ec
-          - mysqladmin status -uroot -p"${MARIADB_ROOT_PASSWORD}"
+          - "/opt/bitnami/scripts/mariadb/healthcheck.sh"
 
 mariadbPassword: "testpass"
 mariadbUsername: "test"

--- a/charts/dependency/mariadb/values.yaml
+++ b/charts/dependency/mariadb/values.yaml
@@ -62,7 +62,7 @@ probes:
         command:
           - /bin/bash
           - -ec
-          - "/opt/bitnami/scripts/mariadb/healthcheck.sh"
+          - "until /opt/bitnami/scripts/mariadb/healthcheck.sh; do sleep 2; done"
 
   # -- Redainess probe configuration
   # @default -- See below
@@ -79,7 +79,7 @@ probes:
         command:
           - /bin/bash
           - -ec
-          - "/opt/bitnami/scripts/mariadb/healthcheck.sh"
+          - "until /opt/bitnami/scripts/mariadb/healthcheck.sh; do sleep 2; done"
   # -- Startup probe configuration
   # @default -- See below
   startup:
@@ -94,7 +94,7 @@ probes:
         command:
           - /bin/bash
           - -ec
-          - "/opt/bitnami/scripts/mariadb/healthcheck.sh"
+          - "until /opt/bitnami/scripts/mariadb/healthcheck.sh; do sleep 2; done"
 
 mariadbPassword: "testpass"
 mariadbUsername: "test"

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 name: common
 sources: null
 type: library
-version: 9.1.8
+version: 9.1.9

--- a/charts/library/common/templates/lib/controller/_pod.tpl
+++ b/charts/library/common/templates/lib/controller/_pod.tpl
@@ -53,6 +53,7 @@ initContainers:
   {{-  include "common.controller.autopermissions" . | nindent 2 }}
   {{-  include "common.controller.hostpatch" . | nindent 2 }}
   {{-  include "common.dependencies.postgresql.init" . | nindent 2 }}
+  {{-  include "common.dependencies.mariadb.init" . | nindent 2 }}
   {{- if .Release.IsInstall }}
   {{- if .Values.installContainers }}
     {{- $installContainers := list }}

--- a/charts/library/common/templates/lib/dependencies/_mariadbInit.tpl
+++ b/charts/library/common/templates/lib/dependencies/_mariadbInit.tpl
@@ -1,0 +1,23 @@
+{{/*
+This template ensures pods with postgresql dependency have a delayed start
+*/}}
+{{- define "common.dependencies.mariadb.init" -}}
+{{- $pghost := printf "%v-%v" .Release.Name "mariadb" }}
+{{- if .Values.mariadb.enabled }}
+- name: mariadb-init
+  image: "{{ .Values.mariadblImage.repository}}:{{ .Values.mariadblImage.tag }}"
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+  resources:
+  {{- with .Values.resources }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  command:
+    - "bash"
+    - "-ec"
+    - "/opt/bitnami/scripts/mariadb/healthcheck.sh"
+  imagePullPolicy: IfNotPresent
+{{- end }}
+{{- end -}}

--- a/charts/library/common/templates/lib/dependencies/_mariadbInit.tpl
+++ b/charts/library/common/templates/lib/dependencies/_mariadbInit.tpl
@@ -17,7 +17,7 @@ This template ensures pods with postgresql dependency have a delayed start
   command:
     - "bash"
     - "-ec"
-    - "/opt/bitnami/scripts/mariadb/healthcheck.sh"
+    - "until /opt/bitnami/scripts/mariadb/healthcheck.sh; do sleep 2; done"
   imagePullPolicy: IfNotPresent
 {{- end }}
 {{- end -}}

--- a/charts/library/common/templates/lib/dependencies/_mariadbInit.tpl
+++ b/charts/library/common/templates/lib/dependencies/_mariadbInit.tpl
@@ -6,6 +6,17 @@ This template ensures pods with postgresql dependency have a delayed start
 {{- if .Values.mariadb.enabled }}
 - name: mariadb-init
   image: "{{ .Values.mariadblImage.repository}}:{{ .Values.mariadblImage.tag }}"
+  env:
+  - name: MARIADB_HOST
+    valueFrom:
+      secretKeyRef:
+        name: mariadbcreds
+        key: plainhost
+  - name: MARIADB_ROOT_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: mariadbcreds
+        key: mariadb-root-password
   securityContext:
     capabilities:
       drop:
@@ -17,7 +28,7 @@ This template ensures pods with postgresql dependency have a delayed start
   command:
     - "bash"
     - "-ec"
-    - "until /opt/bitnami/scripts/mariadb/healthcheck.sh; do sleep 2; done"
+    - "until mysqladmin -uroot -h"${MARIADB_HOST}" -p"${MARIADB_ROOT_PASSWORD}" ping &&  mysqladmin -uroot -h"${MARIADB_HOST}" -p"${MARIADB_ROOT_PASSWORD}" status; do sleep 2; done"
   imagePullPolicy: IfNotPresent
 {{- end }}
 {{- end -}}

--- a/charts/library/common/templates/lib/dependencies/_mariadbInit.tpl
+++ b/charts/library/common/templates/lib/dependencies/_mariadbInit.tpl
@@ -28,7 +28,7 @@ This template ensures pods with postgresql dependency have a delayed start
   command:
     - "bash"
     - "-ec"
-    - "until mysqladmin -uroot -h"${MARIADB_HOST}" -p"${MARIADB_ROOT_PASSWORD}" ping &&  mysqladmin -uroot -h"${MARIADB_HOST}" -p"${MARIADB_ROOT_PASSWORD}" status; do sleep 2; done"
+    - "until mysqladmin -uroot -h"${MARIADB_HOST}" -p"${MARIADB_ROOT_PASSWORD}" ping && mysqladmin -uroot -h"${MARIADB_HOST}" -p"${MARIADB_ROOT_PASSWORD}" status; do sleep 2; done"
   imagePullPolicy: IfNotPresent
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #2205

**⚙️ Type of change**

- [x] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

Bitnami includes a healthcheck script which runs both a `mysqladmin status` and a `mysqladmin ping`

https://github.com/bitnami/bitnami-docker-mariadb/blob/d67ec83926b5544142c21e0965b00630fce4ad22/10.6/debian-10/rootfs/opt/bitnami/scripts/libmariadb.sh#L1287-L1296

Also added init container (copy pasted from postgres), which hopefully it will wait until mariadb is ready before rest of the init containers continue.



* Healthcheck returns `0` only after the database is created and db port is open. 
It still returns `0` while mariadb still runs `mysql_upgrade`. But at this point db seems to be usable (tried to create a table and worked). 

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
