### PR TITLE
docs: Make links blue and underlined 

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -4,3 +4,11 @@
   --md-primary-fg-color--dark:  #000000;
   --md-footer-bg-color--dark:   #000000;
 }
+
+:root > * {
+  --md-typeset-a-color: var(--md-accent-fg-color);
+}
+
+a {
+  text-decoration: underline;
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -5,10 +5,10 @@
   --md-footer-bg-color--dark:   #000000;
 }
 
-:root > * {
+.md-content {
   --md-typeset-a-color: var(--md-accent-fg-color);
 }
 
-a {
+.md-content a {
   text-decoration: underline;
 }


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  #2221.

Before:

![The text "Check TrueCharts Quick-Start Guides for more information." All the text is black.](https://user-images.githubusercontent.com/7763597/159139049-f8064ecc-c531-43ba-9372-6a5f1c752813.png)

After:

![The text "Check TrueCharts Quick-Start Guides for more information." The words "Quick-Start Guides" are blue and underlined.](https://user-images.githubusercontent.com/7763597/159139132-c3d0f4a3-8e77-4af6-94bd-4290bc0a72fd.png)

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

I opened a local copy of the website with `mkdocs serve` and opened various pages. They were identical to [the published version](https://truecharts.org/) except for the style of links.

**📃 Notes:**

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
