### PR TITLE
fix(docs): Traefik install video link update

### DIFF
--- a/docs/manual/Quick-Start Guides/08-installing-Traefik.md
+++ b/docs/manual/Quick-Start Guides/08-installing-Traefik.md
@@ -4,4 +4,4 @@ Within TrueCharts our aim is to make it as easy as possible to secure your Apps.
 
 #### Video Guide
 
-![type:video](https://www.youtube.com/embed/bWNPfrKjawIo)
+![type:video](https://www.youtube.com/embed/bWNPfrKjawI)


### PR DESCRIPTION
**Description**
Documentation for Traefik install links to a wrong video ID thus making it not work. This changes it to the correct URL.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
Checking the correct embed URL from youtube

**📃 Notes:**
N/A

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
