### PR TITLE
feat(common): Add ability to render volsync mover resources

### DIFF
--- a/charts/library/common-test/tests/volsync/replication_dest_spec_test.yaml
+++ b/charts/library/common-test/tests/volsync/replication_dest_spec_test.yaml
@@ -70,6 +70,13 @@ tests:
               capacity: 100Gi
               accessModes:
                 - ReadWriteOnce
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568
@@ -140,6 +147,13 @@ tests:
               capacity: 100Gi
               accessModes:
                 - ReadWriteOnce
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568
@@ -185,6 +199,13 @@ tests:
               capacity: 200Gi
               accessModes:
                 - ReadWriteOnce
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568
@@ -231,6 +252,13 @@ tests:
               accessModes:
                 - ReadWriteOnce
               storageClassName: somestorageclass
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568
@@ -277,6 +305,13 @@ tests:
               accessModes:
                 - ReadWriteOnce
               volumeSnapshotClassName: somevsc
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568
@@ -325,6 +360,13 @@ tests:
                 - ReadWriteOnce
               storageClassName: somestorageclass
               volumeSnapshotClassName: somevsc
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568
@@ -370,6 +412,13 @@ tests:
               capacity: 100Gi
               accessModes:
                 - ReadWriteOnce
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568
@@ -416,6 +465,13 @@ tests:
               capacity: 200Gi
               accessModes:
                 - ReadWriteOnce
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568
@@ -491,6 +547,13 @@ tests:
               capacity: 100Gi
               accessModes:
                 - ReadWriteOnce
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568
@@ -566,6 +629,13 @@ tests:
               capacity: 100Gi
               accessModes:
                 - ReadWriteOnce
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568
@@ -648,6 +718,13 @@ tests:
               capacity: 100Gi
               accessModes:
                 - ReadWriteOnce
+              moverResources:
+                limits:
+                  cpu: 1500m
+                  memory: 2400Mi
+                requests:
+                  cpu: 75m
+                  memory: 200Mi
               moverSecurityContext:
                 fsGroup: 568
                 runAsUser: 568

--- a/charts/library/common-test/tests/volsync/replication_src_spec_test.yaml
+++ b/charts/library/common-test/tests/volsync/replication_src_spec_test.yaml
@@ -73,6 +73,13 @@ tests:
               yearly: 1
             accessModes:
               - ReadWriteOnce
+            moverResources:
+              limits:
+                cpu: 1500m
+                memory: 2400Mi
+              requests:
+                cpu: 75m
+                memory: 200Mi
             moverSecurityContext:
               fsGroup: 568
               runAsUser: 568
@@ -150,6 +157,13 @@ tests:
               yearly: 1
             accessModes:
               - ReadWriteOnce
+            moverResources:
+              limits:
+                cpu: 1500m
+                memory: 2400Mi
+              requests:
+                cpu: 75m
+                memory: 200Mi
             moverSecurityContext:
               fsGroup: 568
               runAsUser: 568
@@ -218,6 +232,13 @@ tests:
               yearly: 2
             accessModes:
               - ReadWriteOnce
+            moverResources:
+              limits:
+                cpu: 1500m
+                memory: 2400Mi
+              requests:
+                cpu: 75m
+                memory: 200Mi
             moverSecurityContext:
               fsGroup: 568
               runAsUser: 568
@@ -282,6 +303,13 @@ tests:
             accessModes:
               - ReadWriteOnce
             storageClassName: somestorageclass
+            moverResources:
+              limits:
+                cpu: 1500m
+                memory: 2400Mi
+              requests:
+                cpu: 75m
+                memory: 200Mi
             moverSecurityContext:
               fsGroup: 568
               runAsUser: 568
@@ -346,6 +374,13 @@ tests:
             accessModes:
               - ReadWriteOnce
             volumeSnapshotClassName: somevsc
+            moverResources:
+              limits:
+                cpu: 1500m
+                memory: 2400Mi
+              requests:
+                cpu: 75m
+                memory: 200Mi
             moverSecurityContext:
               fsGroup: 568
               runAsUser: 568
@@ -412,6 +447,13 @@ tests:
               - ReadWriteOnce
             storageClassName: somestorageclass
             volumeSnapshotClassName: somevsc
+            moverResources:
+              limits:
+                cpu: 1500m
+                memory: 2400Mi
+              requests:
+                cpu: 75m
+                memory: 200Mi
             moverSecurityContext:
               fsGroup: 568
               runAsUser: 568
@@ -498,6 +540,13 @@ tests:
               yearly: 1
             accessModes:
               - ReadWriteOnce
+            moverResources:
+              limits:
+                cpu: 1500m
+                memory: 2400Mi
+              requests:
+                cpu: 75m
+                memory: 200Mi
             moverSecurityContext:
               fsGroup: 568
               runAsUser: 568
@@ -584,6 +633,13 @@ tests:
               yearly: 1
             accessModes:
               - ReadWriteOnce
+            moverResources:
+              limits:
+                cpu: 1500m
+                memory: 2400Mi
+              requests:
+                cpu: 75m
+                memory: 200Mi
             moverSecurityContext:
               fsGroup: 568
               runAsUser: 568
@@ -677,6 +733,13 @@ tests:
               yearly: 1
             accessModes:
               - ReadWriteOnce
+            moverResources:
+              limits:
+                cpu: 1500m
+                memory: 2400Mi
+              requests:
+                cpu: 75m
+                memory: 200Mi
             moverSecurityContext:
               fsGroup: 568
               runAsUser: 568

--- a/charts/library/common/Chart.yaml
+++ b/charts/library/common/Chart.yaml
@@ -52,4 +52,4 @@ sources:
   - https://github.com/trueforge-org/truecharts/tree/master/charts/library/common
   - https://hub.docker.com/_/
 type: library
-version: 29.2.3
+version: 29.3.0

--- a/charts/library/common/templates/class/volsync/_replicationDestination.tpl
+++ b/charts/library/common/templates/class/volsync/_replicationDestination.tpl
@@ -33,7 +33,13 @@ objectData:
   {{- end -}}
   {{- if $volsyncData.dest.capacity -}}
     {{- $capacity = $volsyncData.dest.capacity -}}
-  {{- end }}
+  {{- end -}}
+
+  {{- if not (hasKey $volsyncData "resources") -}}
+    {{- $_ := set $volsyncData "resources" dict -}}
+  {{- end -}}
+  {{/* Exclude extra resources */}}
+  {{- $_ := set $volsyncData.resources "excludeExtra" true }}
 ---
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
@@ -67,6 +73,10 @@ spec:
     {{- end }}
     cleanupTempPVC: {{ $cleanupTempPVC }}
     cleanupCachePVC: {{ $cleanupCachePVC }}
+    {{- with (include "tc.v1.common.lib.container.resources" (dict "rootCtx" $rootCtx "objectData" $volsyncData) | trim) }}
+    moverResources:
+      {{- . | nindent 6 }}
+    {{- end }}
   {{- include "tc.v1.common.lib.volsync.storage" (dict "rootCtx" $rootCtx "objectData" $objectData "volsyncData" $volsyncData "target" "dest") | trim | nindent 4 }}
   {{- include "tc.v1.common.lib.volsync.cache" (dict "rootCtx" $rootCtx "objectData" $objectData "volsyncData" $volsyncData "target" "dest") | trim | nindent 4 }}
   {{- include "tc.v1.common.lib.volsync.moversecuritycontext" (dict "rootCtx" $rootCtx "objectData" $objectData "volsyncData" $volsyncData "target" "dest") | trim | nindent 4 }}

--- a/charts/library/common/templates/class/volsync/_replicationSource.tpl
+++ b/charts/library/common/templates/class/volsync/_replicationSource.tpl
@@ -30,7 +30,13 @@ objectData:
         {{- $_ := set $retain $item . -}}
       {{- end -}}
     {{- end -}}
-  {{- end }}
+  {{- end -}}
+
+  {{- if not (hasKey $volsyncData "resources") -}}
+    {{- $_ := set $volsyncData "resources" dict -}}
+  {{- end -}}
+  {{/* Exclude extra resources */}}
+  {{- $_ := set $volsyncData.resources "excludeExtra" true }}
 ---
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
@@ -67,6 +73,10 @@ spec:
       weekly: {{ $retain.weekly }}
       monthly: {{ $retain.monthly }}
       yearly: {{ $retain.yearly }}
+    {{- with (include "tc.v1.common.lib.container.resources" (dict "rootCtx" $rootCtx "objectData" $volsyncData) | trim) }}
+    moverResources:
+      {{- . | nindent 6 }}
+    {{- end }}
     {{- include "tc.v1.common.lib.volsync.storage" (dict "rootCtx" $rootCtx "objectData" $objectData "volsyncData" $volsyncData "target" "src") | trim | nindent 4 }}
     {{- include "tc.v1.common.lib.volsync.cache" (dict "rootCtx" $rootCtx "objectData" $objectData "volsyncData" $volsyncData "target" "src") | trim | nindent 4 }}
     {{- include "tc.v1.common.lib.volsync.moversecuritycontext" (dict "rootCtx" $rootCtx "objectData" $objectData "volsyncData" $volsyncData "target" "src") | trim | nindent 4 }}


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes  # <!--(issue)-->

Adds ability to render volsync mover pod resource sections, which was previously not possible.

Volsync mover pods run without any requests or limits set by default. This MR changes this behaviour by rendering a `moverResources` section in each `ReplicationDestination` or `ReplicationSource` CRD. If no resources are provided for a volsync mover - it uses the chart defaults.

**⚙️ Type of change**

- [X] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

CI. 

Also rendered a chart via `helm template` and looked at the rendered `ReplicationDestination` and `ReplicationSource` resources when volsync is enabled for PVC.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

Originally opened against the `master` branch (https://github.com/trueforge-org/truecharts/pull/46652), however, I received feedback it should be opened against `common2026` instead.

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [X] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
- [X] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
