### PR TITLE
chore(maintainerr): update image and source URLs after upstream rename

### DIFF
--- a/charts/stable/maintainerr/Chart.yaml
+++ b/charts/stable/maintainerr/Chart.yaml
@@ -32,9 +32,8 @@ maintainers:
     url: https://truecharts.org
 name: maintainerr
 sources:
-  - https://github.com/jorenn92/Maintainerr
+  - https://github.com/Maintainerr/Maintainerr
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/maintainerr
-  - https://hub.docker.com/r/jorenn92/maintainerr
+  - https://hub.docker.com/r/maintainerr/maintainerr
 type: application
-version: 7.4.1
-
+version: 7.4.2

--- a/charts/stable/maintainerr/values.yaml
+++ b/charts/stable/maintainerr/values.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=./values.schema.json
 image:
-  repository: docker.io/jorenn92/maintainerr
+  repository: docker.io/maintainerr/maintainerr
   pullPolicy: IfNotPresent
   tag: 3.7.0@sha256:bfc9d16c3f752e17432e5a66df5bbeb4c115698f9dd496ee03fd0aa9ef3dca52
 


### PR DESCRIPTION
## Summary

Updates the Maintainerr chart to reference the renamed upstream repo and Docker namespace.

On 2026-01-31 the Maintainerr project moved from `jorenn92/Maintainerr` → [`Maintainerr/Maintainerr`](https://github.com/Maintainerr/Maintainerr) on GitHub, and the canonical Docker image is now [`maintainerr/maintainerr`](https://hub.docker.com/r/maintainerr/maintainerr). The legacy `jorenn92/maintainerr` Hub namespace is still mirrored, but new builds and the source of truth live in the new namespace.

## Changes

**`charts/stable/maintainerr/values.yaml`**
- `image.repository`: `docker.io/jorenn92/maintainerr` → `docker.io/maintainerr/maintainerr`
- `image.tag`: digest pin **unchanged** — both `jorenn92/maintainerr:3.7.0` and `maintainerr/maintainerr:3.7.0` are published from the same release workflow and resolve to the same manifest digest (`sha256:bfc9d16c3f752e17432e5a66df5bbeb4c115698f9dd496ee03fd0aa9ef3dca52`). Verified via `docker buildx imagetools inspect maintainerr/maintainerr:3.7.0` and the Docker Hub Registry API.

**`charts/stable/maintainerr/Chart.yaml`**
- `sources`: updated GitHub and Docker Hub URLs to the new namespaces
- `version`: bumped patch `7.4.1` → `7.4.2` (please adjust if your release process uses a different bump policy)

## Test plan

- [ ] `helm lint charts/stable/maintainerr`
- [ ] CI digest re-pin (if required by your bumper)
- [ ] Render and deploy in a sandbox; confirm pod pulls the new image and the WebUI is reachable on `6246`
