### PR TITLE
fix(multus-cni): Remove unsupported -o pipefail option from sh scripts

### DIFF
--- a/charts/stable/multus-cni/Chart.yaml
+++ b/charts/stable/multus-cni/Chart.yaml
@@ -39,5 +39,5 @@ sources:
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/multus-cni
   - https://hub.docker.com/r/alpine/crane
 type: application
-version: 2.0.4
+version: 2.0.5
 

--- a/charts/stable/multus-cni/values.yaml
+++ b/charts/stable/multus-cni/values.yaml
@@ -260,7 +260,7 @@ workload:
             - sh
             - -c
             - |
-              set -euo pipefail
+              set -eu
               cd /tmp
 
               echo "Pulling '{{ .Values.talosCniImage.repository }}:{{ .Values.talosCniImage.tag }}' image..."
@@ -328,7 +328,7 @@ workload:
                 eval "$@"
               }
 
-              set -euo pipefail
+              set -eu
 
               echo "Cleaning up Multus CNI config..."
               echoRun rm -rf "{{ tpl .Values.persistence.cniconf.mountPath $ }}"/*multus.*
@@ -424,7 +424,7 @@ workload:
             - sh
             - -c
             - |
-              set -euo pipefail
+              set -eu
 
               SOCKET_PATH="{{ tpl .Values.persistence.hostrun.mountPath $ }}/cni/dhcp.sock"
               CNI_BIN_DIR="{{ (tpl .Values.persistence.cnibin.mountPath $) }}"


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Not sure how this wasn't a problem before but I recently upgraded the chart ot a more recent version and started getting:

```
sh: 1: set: Illegal option -o pipefail
```

pipefail is not supprted by `sh`, so it needs to be removed.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [X] ⬆️ I increased versions for any altered app according to semantic versioning
- [X] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
