### PR TITLE
fix(paperless-ngx) Set PAPERLESS_DBENGINE as it is required from paperless-ngx 3.0+

### DIFF
--- a/charts/stable/paperless-ngx/Chart.yaml
+++ b/charts/stable/paperless-ngx/Chart.yaml
@@ -48,5 +48,5 @@ sources:
   - https://hub.docker.com/r/gotenberg/gotenberg
   - https://paperless-ngx.readthedocs.io/en/latest/
 type: application
-version: 15.2.1
+version: 15.2.2
 

--- a/charts/stable/paperless-ngx/values.yaml
+++ b/charts/stable/paperless-ngx/values.yaml
@@ -89,6 +89,7 @@ workload:
             USERMAP_UID: "{{ .Values.securityContext.container.PUID }}"
             USERMAP_GID: "{{ .Values.securityContext.pod.fsGroup }}"
             PAPERLESS_TIME_ZONE: "{{ .Values.TZ }}"
+            PAPERLESS_DBENGINE: "postgresql"
             PAPERLESS_DBNAME: "{{ .Values.cnpg.main.database }}"
             PAPERLESS_DBUSER: "{{ .Values.cnpg.main.user }}"
             PAPERLESS_DBPORT: "5432"


### PR DESCRIPTION
**Description**
With paperless 3.0+ a new environment variable `PAPERLESS_DBENGINE` is required when using PostgreSQL.

See the migration guide of paperless-ngx: https://docs.paperless-ngx.com/migration-v3/#database-engine

This PR adds the variable.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
Not tested yet, because i don't want to ruin my paperless installation and don't have the time to spin up a separate cluster...

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [x] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
