### PR TITLE
fix(homebridge): switch to ghcr.io and update to latest image (2026-07-31)

### DIFF
--- a/charts/stable/homebridge/Chart.yaml
+++ b/charts/stable/homebridge/Chart.yaml
@@ -9,7 +9,7 @@ annotations:
   trueforge.org/min_helm_version: "3.14"
   trueforge.org/train: stable
 apiVersion: v2
-appVersion: 2025.7.25
+appVersion: 2026.7.31
 dependencies:
   - name: common
     version: 29.10.4
@@ -32,10 +32,10 @@ maintainers:
     url: https://truecharts.org
 name: homebridge
 sources:
+  - https://ghcr.io/homebridge/homebridge
   - https://github.com/oznu/docker-homebridge
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/homebridge
   - https://homebridge.io/
-  - https://hub.docker.com/r/homebridge/homebridge
 type: application
-version: 12.7.0
+version: 12.7.1
 

--- a/charts/stable/homebridge/Chart.yaml
+++ b/charts/stable/homebridge/Chart.yaml
@@ -37,5 +37,5 @@ sources:
   - https://github.com/trueforge-org/truecharts/tree/master/charts/stable/homebridge
   - https://homebridge.io/
 type: application
-version: 12.7.1
+version: 13.0.0
 

--- a/charts/stable/homebridge/values.yaml
+++ b/charts/stable/homebridge/values.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=./values.schema.json
 image:
-  repository: docker.io/homebridge/homebridge
-  tag: 2025-07-25@sha256:6f869d799bfe7c203b7d46a8dcba382005eaf66a5dd6940874c46ebf211b0bae
+  repository: ghcr.io/homebridge/homebridge
+  tag: 2026-07-31@sha256:29bde0c4deb600b8d583267606179ddcac78c75a24799064de9d341781567bda
   pullPolicy: IfNotPresent
 
 securityContext:


### PR DESCRIPTION
**Description**
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
⚒️ Fixes #50678

Bumps the stale pinned image (`2025-07-25`, a year old) to the latest upstream release, `2026-07-31`. Also switches `image.repository` from `docker.io/homebridge/homebridge` to `ghcr.io/homebridge/homebridge`, per @alfi0812's note on the issue.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [ ] 📜 Documentation Changes

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->
Running this exact image (`ghcr.io/homebridge/homebridge:2026-07-31`, same digest as pinned in the values.yaml change) in a live cluster now. Pod is healthy, all plugins and cached accessories loaded cleanly, web UI reachable.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made changes to the documentation
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [x] ⬆️ I increased versions for any altered app according to semantic versioning
- [x] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):`, `chore(chart-name):`, `docs(chart-name):` or `fix(docs):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
