### PR TITLE
chore(renovate): point homebridge custom versioning at ghcr.io

### DIFF
--- a/.github/renovate/special/customVersioning.json5
+++ b/.github/renovate/special/customVersioning.json5
@@ -61,7 +61,7 @@
     {
       "matchDatasources": ["docker"],
       "versioning": "regex:^(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})$",
-      "matchPackagePatterns": ["docker.io/homebridge/homebridge"]
+      "matchPackagePatterns": ["ghcr.io/homebridge/homebridge"]
     },
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
Companion to #50995. The existing custom versioning rule for homebridge's date-based tags matches on `matchPackagePatterns: ["docker.io/homebridge/homebridge"]`. Once #50995 switches the chart to `ghcr.io/homebridge/homebridge`, that pattern would stop matching the new package name and Renovate would fall back to default SemVer versioning — which can't parse `YYYY-MM-DD` tags — silently breaking future auto-updates again. This just keeps the pattern aligned with the new registry.

Note: I verified the regex itself (`^(?<major>\d{4})-(?<minor>\d{2})-(?<patch>\d{2})$`) is correct and was working — Renovate merged bump PRs for this package for years, most recently #37642 (2025-07-28). Something else stopped new PRs after that for about a year; I don't have visibility into your Renovate run logs to diagnose that part, so I'm not claiming this PR fixes the root cause — just avoiding a second break from the registry switch.
